### PR TITLE
Modify snapshot method

### DIFF
--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -1,7 +1,6 @@
 ﻿using FFMpegCore.Enums;
 using FFMpegCore.FFMPEG.Argument;
 using FFMpegCore.FFMPEG.Enums;
-using FFMpegCore.Test;
 using FFMpegCore.Test.Resources;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
@@ -32,7 +31,8 @@ namespace FFMpegCore.Test
                 {
                     Assert.AreEqual(outputVideo.Width, input.Width);
                     Assert.AreEqual(outputVideo.Height, input.Height);
-                } else
+                }
+                else
                 {
                     Assert.AreNotEqual(outputVideo.Width, input.Width);
                     Assert.AreNotEqual(outputVideo.Height, input.Height);
@@ -90,7 +90,8 @@ namespace FFMpegCore.Test
                 {
                     Assert.AreEqual(outputVideo.Width, input.Width);
                     Assert.AreEqual(outputVideo.Height, input.Height);
-                } else
+                }
+                else
                 {
                     if (scaling.Value.Width != -1)
                     {
@@ -212,6 +213,29 @@ namespace FFMpegCore.Test
                     Assert.AreEqual(input.Width, bitmap.Width);
                     Assert.AreEqual(input.Height, bitmap.Height);
                     Assert.AreEqual(bitmap.RawFormat, ImageFormat.Png);
+                }
+            }
+            finally
+            {
+                if (File.Exists(output.FullName))
+                    File.Delete(output.FullName);
+            }
+        }
+
+        [TestMethod]
+        public void Video_Snapshot_PersistSnapshot()
+        {
+            var output = Input.OutputLocation(ImageType.Png);
+            try
+            {
+                var input = VideoInfo.FromFileInfo(Input);
+
+                using (var bitmap = Encoder.Snapshot(input, output, persistSnapshotOnFileSystem: true))
+                {
+                    Assert.AreEqual(input.Width, bitmap.Width);
+                    Assert.AreEqual(input.Height, bitmap.Height);
+                    Assert.AreEqual(bitmap.RawFormat, ImageFormat.Png);
+                    Assert.IsTrue(File.Exists(output.FullName));
                 }
             }
             finally

--- a/FFMpegCore/FFMPEG/FFMpeg.cs
+++ b/FFMpegCore/FFMPEG/FFMpeg.cs
@@ -48,8 +48,9 @@ namespace FFMpegCore.FFMPEG
         /// <param name="output">Output video file</param>
         /// <param name="captureTime">Seek position where the thumbnail should be taken.</param>
         /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
+        /// <param name="persistSnapshotOnFileSystem">By default, it deletes the created image on disk. If set to true, it won't delete the image</param>
         /// <returns>Bitmap with the requested snapshot.</returns>
-        public Bitmap Snapshot(VideoInfo source, FileInfo output, Size? size = null, TimeSpan? captureTime = null)
+        public Bitmap Snapshot(VideoInfo source, FileInfo output, Size? size = null, TimeSpan? captureTime = null, bool persistSnapshotOnFileSystem = false)
         {
             if (captureTime == null)
                 captureTime = TimeSpan.FromSeconds(source.Duration.TotalSeconds / 3);
@@ -108,7 +109,10 @@ namespace FFMpegCore.FFMPEG
 
             if (output.Exists)
             {
-                output.Delete();
+                if (!persistSnapshotOnFileSystem)
+                {
+                    output.Delete();
+                }
             }
 
             return result;

--- a/FFMpegCore/FFMPEG/FFMpeg.cs
+++ b/FFMpegCore/FFMPEG/FFMpeg.cs
@@ -107,12 +107,9 @@ namespace FFMpegCore.FFMPEG
                 }
             }
 
-            if (output.Exists)
+            if (output.Exists && !persistSnapshotOnFileSystem)
             {
-                if (!persistSnapshotOnFileSystem)
-                {
-                    output.Delete();
-                }
+                output.Delete();
             }
 
             return result;


### PR DESCRIPTION
When a snapshot is needeed, it's overkill to create the image on the filesystem, then delete it, and then create the image on the filesystem again. With this feature we can avoid this scenario and actually persist the created image on disk.