### PR TITLE
update to make operating system independent 

### DIFF
--- a/FFMpegCore.Test/FFMpegOptions.cs
+++ b/FFMpegCore.Test/FFMpegOptions.cs
@@ -17,7 +17,7 @@ namespace FFMpegCore.Test
         [TestMethod]
         public void Options_Defaults_Configured()
         {
-            Assert.AreEqual(new FFMpegOptions().RootDirectory, ".\\FFMPEG\\bin");
+            Assert.AreEqual(new FFMpegOptions().RootDirectory, $".{Path.DirectorySeparatorChar}FFMPEG{Path.DirectorySeparatorChar}bin");
         }
 
         [TestMethod]
@@ -25,7 +25,7 @@ namespace FFMpegCore.Test
         {
             Assert.AreEqual(
                 FFMpegOptions.Options.RootDirectory, 
-                JsonConvert.DeserializeObject<FFMpegOptions>(File.ReadAllText(".\\ffmpeg.config.json")).RootDirectory
+                JsonConvert.DeserializeObject<FFMpegOptions>(File.ReadAllText($".{Path.DirectorySeparatorChar}ffmpeg.config.json")).RootDirectory
             );
         }
 

--- a/FFMpegCore.Test/Resources/VideoLibrary.cs
+++ b/FFMpegCore.Test/Resources/VideoLibrary.cs
@@ -16,13 +16,13 @@ namespace FFMpegCore.Test.Resources
 
     public static class VideoLibrary
     {
-        public static readonly FileInfo LocalVideo = new FileInfo(".\\Resources\\input.mp4");
-        public static readonly FileInfo LocalVideoAudioOnly = new FileInfo(".\\Resources\\audio_only.mp4");
-        public static readonly FileInfo LocalVideoNoAudio = new FileInfo(".\\Resources\\mute.mp4");
-        public static readonly FileInfo LocalAudio = new FileInfo(".\\Resources\\audio.mp3");
-        public static readonly FileInfo LocalCover = new FileInfo(".\\Resources\\cover.png");
-        public static readonly FileInfo ImageDirectory = new FileInfo(".\\Resources\\images");
-        public static readonly FileInfo ImageJoinOutput = new FileInfo(".\\Resources\\images\\output.mp4");
+        public static readonly FileInfo LocalVideo = new FileInfo($".{Path.DirectorySeparatorChar}Resources{Path.DirectorySeparatorChar}input.mp4");
+        public static readonly FileInfo LocalVideoAudioOnly = new FileInfo($".{Path.DirectorySeparatorChar}Resources{Path.DirectorySeparatorChar}audio_only.mp4");
+        public static readonly FileInfo LocalVideoNoAudio = new FileInfo($".{Path.DirectorySeparatorChar}Resources{Path.DirectorySeparatorChar}mute.mp4");
+        public static readonly FileInfo LocalAudio = new FileInfo($".{Path.DirectorySeparatorChar}Resources{Path.DirectorySeparatorChar}audio.mp3");
+        public static readonly FileInfo LocalCover = new FileInfo($".{Path.DirectorySeparatorChar}Resources{Path.DirectorySeparatorChar}cover.png");
+        public static readonly FileInfo ImageDirectory = new FileInfo($".{Path.DirectorySeparatorChar}Resources{Path.DirectorySeparatorChar}images");
+        public static readonly FileInfo ImageJoinOutput = new FileInfo($".{Path.DirectorySeparatorChar}Resources{Path.DirectorySeparatorChar}images{Path.DirectorySeparatorChar}output.mp4");
 
         public static FileInfo OutputLocation(this FileInfo file, VideoType type)
         {
@@ -44,7 +44,7 @@ namespace FFMpegCore.Test.Resources
             string originalLocation = file.Directory.FullName,
                 outputFile = file.Name.Replace(file.Extension, keyword + "." + type.ToString().ToLower());
 
-            return new FileInfo($"{originalLocation}\\{outputFile}");
+            return new FileInfo($"{originalLocation}{Path.DirectorySeparatorChar}{outputFile}");
         }
     }
 }

--- a/FFMpegCore/FFMPEG/FFMpeg.cs
+++ b/FFMpegCore/FFMPEG/FFMpeg.cs
@@ -11,6 +11,7 @@ using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -29,9 +30,16 @@ namespace FFMpegCore.FFMPEG
         {
             FFMpegHelper.RootExceptionCheck(FFMpegOptions.Options.RootDirectory);
 
-            var target = Environment.Is64BitProcess ? "x64" : "x86";
+            var progName = "ffmpeg";
+            if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows)) {
+                var target = Environment.Is64BitProcess ? "x64" : "x86";
 
-            _ffmpegPath = $"{FFMpegOptions.Options.RootDirectory}\\{target}\\ffmpeg.exe";
+                progName = $"{target}{Path.DirectorySeparatorChar}{progName}.exe";
+            }
+
+            var path = $"{Path.DirectorySeparatorChar}{progName}";
+
+            _ffmpegPath = $"{FFMpegOptions.Options.RootDirectory}{path}";
 
             ArgumentBuilder = new FFArgumentBuilder();
         }
@@ -302,7 +310,7 @@ namespace FFMpegCore.FFMPEG
                 new FrameRateArgument(frameRate),
                 new SizeArgument(firstImage.Width, firstImage.Height),
                 new StartNumberArgument(0),
-                new InputArgument($"{firstImage.Directory}\\%09d.png"),
+                new InputArgument($"{firstImage.Directory}{Path.DirectorySeparatorChar}%09d.png"),
                 new FrameOutputCountArgument(images.Length),
                 new VideoCodecArgument(VideoCodec.LibX264),
                 new OutputArgument(output)

--- a/FFMpegCore/FFMPEG/FFMpegOptions.cs
+++ b/FFMpegCore/FFMPEG/FFMpegOptions.cs
@@ -5,8 +5,8 @@ namespace FFMpegCore.FFMPEG
 {
     public class FFMpegOptions
     {
-        private static string _ConfigFile = ".\\ffmpeg.config.json";
-        private static string _DefaultRoot = ".\\FFMPEG\\bin";
+        private static string _ConfigFile = $".{Path.DirectorySeparatorChar}ffmpeg.config.json";
+        private static string _DefaultRoot = $".{Path.DirectorySeparatorChar}FFMPEG{Path.DirectorySeparatorChar}bin";
 
         public static FFMpegOptions Options { get; private set; } = new FFMpegOptions();
 

--- a/FFMpegCore/FFMPEG/FFProbe.cs
+++ b/FFMpegCore/FFMPEG/FFProbe.cs
@@ -3,6 +3,8 @@ using FFMpegCore.Helpers;
 using Newtonsoft.Json;
 using System;
 using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace FFMpegCore.FFMPEG
 {
@@ -14,9 +16,16 @@ namespace FFMpegCore.FFMPEG
         {
             FFProbeHelper.RootExceptionCheck(FFMpegOptions.Options.RootDirectory);
 
-            var target = Environment.Is64BitProcess ? "x64" : "x86";
+            var progName = "ffprobe";
+            if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows)) {
+                var target = Environment.Is64BitProcess ? "x64" : "x86";
 
-            _ffprobePath = $"{FFMpegOptions.Options.RootDirectory}\\{target}\\ffprobe.exe";
+                progName = $"{target}{Path.DirectorySeparatorChar}{progName}.exe";
+            }
+
+            var path = $"{Path.DirectorySeparatorChar}{progName}";
+
+            _ffprobePath = $"{FFMpegOptions.Options.RootDirectory}{path}";
         }
 
         /// <summary>

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -140,7 +140,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
   </ItemGroup>
 

--- a/FFMpegCore/Helpers/FFMpegHelper.cs
+++ b/FFMpegCore/Helpers/FFMpegHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.IO;
+using System.Runtime.InteropServices;
 using FFMpegCore.FFMPEG.Exceptions;
 
 namespace FFMpegCore.Helpers
@@ -73,9 +74,14 @@ namespace FFMpegCore.Helpers
                 throw new FFMpegException(FFMpegExceptionType.Dependency,
                     "FFMpeg root is not configured in app config. Missing key 'ffmpegRoot'.");
 
-            var target = Environment.Is64BitProcess ? "x64" : "x86";
+            var progName = "ffmpeg";
+            if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows)) {
+                var target = Environment.Is64BitProcess ? "x64" : "x86";
 
-            var path = root + $"\\{target}\\ffmpeg.exe";
+                progName = $"{target}{Path.DirectorySeparatorChar}{progName}.exe";
+            }
+
+            var path = root + $"{Path.DirectorySeparatorChar}{progName}";
 
             if (!File.Exists(path))
                 throw new FFMpegException(FFMpegExceptionType.Dependency,

--- a/FFMpegCore/Helpers/FFProbeHelper.cs
+++ b/FFMpegCore/Helpers/FFProbeHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using FFMpegCore.FFMPEG.Exceptions;
 
 namespace FFMpegCore.Helpers
@@ -23,9 +24,14 @@ namespace FFMpegCore.Helpers
                 throw new FFMpegException(FFMpegExceptionType.Dependency,
                     "FFProbe root is not configured in app config. Missing key 'ffmpegRoot'.");
 
-            var target = Environment.Is64BitProcess ? "x64" : "x86";
+            var progName = "ffprobe";
+            if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows)) {
+                var target = Environment.Is64BitProcess ? "x64" : "x86";
 
-            var path = root + $"\\{target}\\ffprobe.exe";
+                progName = $"{target}{Path.DirectorySeparatorChar}{progName}.exe";
+            }
+
+            var path = root + $"{Path.DirectorySeparatorChar}{progName}";
 
             if (!File.Exists(path))
                 throw new FFMpegException(FFMpegExceptionType.Dependency,

--- a/FFMpegCore/ImageInfo.cs
+++ b/FFMpegCore/ImageInfo.cs
@@ -158,7 +158,7 @@ namespace FFMpegCore
         /// <param name="destination"></param>
         public void MoveTo(DirectoryInfo destination)
         {
-            var newLocation = $"{destination.FullName}\\{Name}{Extension}";
+            var newLocation = $"{destination.FullName}{Path.DirectorySeparatorChar}{Name}{Extension}";
             _file.MoveTo(newLocation);
             _file = new FileInfo(newLocation);
         }

--- a/FFMpegCore/VideoInfo.cs
+++ b/FFMpegCore/VideoInfo.cs
@@ -162,7 +162,7 @@ namespace FFMpegCore
         /// <param name="destination"></param>
         public void MoveTo(DirectoryInfo destination)
         {
-            var newLocation = $"{destination.FullName}\\{Name}{Extension}";
+            var newLocation = $"{destination.FullName}{Path.DirectorySeparatorChar}{Name}{Extension}";
             _file.MoveTo(newLocation);
             _file = new FileInfo(newLocation);
         }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ I can only guarantee an expected behaviour built binaries included, other 3rd pa
 MacOSX 
 The Unit test have run on MacOSX - 10.14.4 using ffmpeg version 4.1.3. (It was installed using "brew install ffmpeg" and "brew install mono-libgdiplus"). The RootDirectory was set to "/usr/local/bin" for running unit test.
 
+Ubuntu 16.04
+The unit test failed on 2 test when running against default ffmpeg package of (ffmpeg version 2.8.15-0ubuntu0.16.04.1)
+    The two test that failed were Video_ToMP4_Args and Video_ToMP4_Resize_Args
+The Unit test passed when running against ffmpeg version 4.1.3
+
 ### FFProbe
 
 FFProbe is used to gather video information

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The files that need to be included can be found here: https://github.com/vladjer
 
 I can only guarantee an expected behaviour built binaries included, other 3rd party builds could contain API changes rendering an unexpected behaviour.
 
+MacOSX 
+The Unit test have run on MacOSX - 10.14.4 using ffmpeg version 4.1.3. (It was installed using "brew install ffmpeg" and "brew install mono-libgdiplus"). The RootDirectory was set to "/usr/local/bin" for running unit test.
+
 ### FFProbe
 
 FFProbe is used to gather video information


### PR DESCRIPTION
-Update various paths to use Path.DirectorySeparatorChar
-Update various calls to ffmpeg.exe and ffprobe.exe to only use .exe if on windows
-Update various calls to ffmpeg.exe and ffprobe.exe to only add target "x86" or "x64" when running within windows

--Added comments to readme for test results for mac and ubuntu and their versions of ffmpeg used in testing