### PR TITLE
Asynchronous public methods for ffprobe

### DIFF
--- a/FFMpegCore/FFMPEG/FFBase.cs
+++ b/FFMpegCore/FFMPEG/FFBase.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using RunProcessAsTask;
 
 namespace FFMpegCore.FFMPEG
 {
@@ -77,6 +79,11 @@ namespace FFMpegCore.FFMPEG
             {
                 IsKillFaulty = true;
             }
+        }
+        protected async Task<string> RunProcessAsync(string filePath, string arguments)
+        {
+            var result = await ProcessEx.RunAsync(filePath, arguments);
+            return string.Join("", result.StandardOutput);
         }
     }
 }

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -130,6 +130,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="RunProcessAsTask" Version="1.2.4" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi,

Would love to use this library for ffmpeg usage, as this project seems alive and fairly complete in regards to FFMpeg support.
I would prefer to keep my ffmpeg processing asynchronous, to away blocking the thread for too long. And ffmpeg conversions often take a long time, and there seems to be no reason to keep the thread belonging to the C# runtime blocked.

I have created async public methods for ffprobe, and I will gladly do the same to FFMpeg.
But then I think it would make sense with a small refactoring in regards to running ff* processes.
Would you mind that?