### PR TITLE
return null when file not exits

### DIFF
--- a/FFMpegCore/FFMPEG/FFMpeg.cs
+++ b/FFMpegCore/FFMPEG/FFMpeg.cs
@@ -390,7 +390,7 @@ namespace FFMpegCore.FFMPEG
                 throw new FFMpegException(FFMpegExceptionType.Conversion, "Could not process file without error");
 
             _totalTime = TimeSpan.MinValue;
-            return new VideoInfo(output);
+            return output.Exists ? new VideoInfo(output) : null;
         }
         public async Task<VideoInfo> ConvertAsync(ArgumentContainer arguments, bool skipExistsCheck = false)
         {
@@ -401,7 +401,7 @@ namespace FFMpegCore.FFMPEG
                 throw new FFMpegException(FFMpegExceptionType.Conversion, "Could not process file without error");
 
             _totalTime = TimeSpan.MinValue;
-            return new VideoInfo(output);
+            return output.Exists ? new VideoInfo(output) : null;
         }
 
         private static (VideoInfo[] Input, FileInfo Output) GetInputOutput(ArgumentContainer arguments)


### PR DESCRIPTION
As we allow to skip exist check, so the out file may not exist, if so we should return a null otherwise we would get an exception returned, as the `VideoInfo` need a file existed