### PR TITLE
Snapshot ，Join   

### DIFF
--- a/FFMpegCore/FFMpeg/Enums/FileExtension.cs
+++ b/FFMpegCore/FFMpeg/Enums/FileExtension.cs
@@ -18,7 +18,7 @@ namespace FFMpegCore.Enums
         }
         public static readonly string Mp4 = ".mp4";
         public static readonly string Mp3 = ".mp3";
-        public static readonly string Ts = ".ts";
+        public static readonly string Ts = ".mpegts";
         public static readonly string Ogv = ".ogv";
         public static readonly string Png = ".png";
         public static readonly string WebM = ".webm";

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -75,18 +75,18 @@ namespace FFMpegCore
             {
                 if (size.Value.Width == 0)
                 {
-                    var ratio = source.PrimaryVideoStream.Height / (double) size.Value.Height;
+                    var ratio = (double)size.Value.Height / source.PrimaryVideoStream.Height;
 
-                    size = new Size((int) (source.PrimaryVideoStream.Width * ratio),
-                        (int) (source.PrimaryVideoStream.Height * ratio));
+                    size = new Size((int)(source.PrimaryVideoStream.Width * ratio),
+                        (int)(source.PrimaryVideoStream.Height * ratio));
                 }
 
                 if (size.Value.Height == 0)
                 {
-                    var ratio = source.PrimaryVideoStream.Width / (double) size.Value.Width;
+                    var ratio = (double)size.Value.Width / source.PrimaryVideoStream.Width;
 
-                    size = new Size((int) (source.PrimaryVideoStream.Width * ratio),
-                        (int) (source.PrimaryVideoStream.Height * ratio));
+                    size = new Size((int)(source.PrimaryVideoStream.Width * ratio),
+                        (int)(source.PrimaryVideoStream.Height * ratio));
                 }
             }
 

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -76,7 +76,7 @@ namespace FFMpegCore
             {
                 if (size.Value.Width == 0)
                 {
-                    var ratio = source.PrimaryVideoStream.Width / (double) size.Value.Width;
+                    var ratio = source.PrimaryVideoStream.Height / (double) size.Value.Height;
 
                     size = new Size((int) (source.PrimaryVideoStream.Width * ratio),
                         (int) (source.PrimaryVideoStream.Height * ratio));
@@ -84,7 +84,7 @@ namespace FFMpegCore
 
                 if (size.Value.Height == 0)
                 {
-                    var ratio = source.PrimaryVideoStream.Height / (double) size.Value.Height;
+                    var ratio = source.PrimaryVideoStream.Width / (double) size.Value.Width;
 
                     size = new Size((int) (source.PrimaryVideoStream.Width * ratio),
                         (int) (source.PrimaryVideoStream.Height * ratio));

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.IO;
-using System.Linq;
-using FFMpegCore.Enums;
+﻿using FFMpegCore.Enums;
 using FFMpegCore.Exceptions;
 using FFMpegCore.Helpers;
 using FFMpegCore.Pipes;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
 
 namespace FFMpegCore
 {


### PR DESCRIPTION
Snapshot: size(x，0) or size(0,x) error
Join:  Invalid output file. File extension should be 'mpegts' required.