### PR TITLE
Change DemuxConcatArgument output to match FFmpeg format

### DIFF
--- a/FFMpegCore/FFMpeg/Arguments/DemuxConcatArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/DemuxConcatArgument.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +16,7 @@ namespace FFMpegCore.Arguments
         public readonly IEnumerable<string> Values;
         public DemuxConcatArgument(IEnumerable<string> values)
         {
-            Values = values;
+            Values = values.Select(value => $"'file '{value}'");
         }
         private readonly string _tempFileName = Path.Combine(FFMpegOptions.Options.TempDirectory, Guid.NewGuid() + ".txt");
 

--- a/FFMpegCore/FFMpeg/Arguments/DemuxConcatArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/DemuxConcatArgument.cs
@@ -16,7 +16,7 @@ namespace FFMpegCore.Arguments
         public readonly IEnumerable<string> Values;
         public DemuxConcatArgument(IEnumerable<string> values)
         {
-            Values = values.Select(value => $"'file '{value}'");
+            Values = values.Select(value => $"file '{value}'");
         }
         private readonly string _tempFileName = Path.Combine(FFMpegOptions.Options.TempDirectory, Guid.NewGuid() + ".txt");
 


### PR DESCRIPTION
FFmpeg demux concatenation requires a text file input in the format of 

`file 'C:\ExampleFile.avi'`

Change DemuxConcatArgument.cs so that it wraps the file paths provided to match this format