### PR TITLE
Introduce IMediaAnalysis interface so FFProbe results are mock friendly

### DIFF
--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -159,7 +159,7 @@ namespace FFMpegCore.Test
             }
         }
 
-        public void Convert(ContainerFormat type, Action<MediaAnalysis> validationMethod, params IArgument[] inputArguments)
+        public void Convert(ContainerFormat type, Action<IMediaAnalysis> validationMethod, params IArgument[] inputArguments)
         {
             var output = Input.OutputLocation(type);
 

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -21,7 +21,7 @@ namespace FFMpegCore
         /// <param name="captureTime">Seek position where the thumbnail should be taken.</param>
         /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
         /// <returns>Bitmap with the requested snapshot.</returns>
-        public static bool Snapshot(MediaAnalysis source, string output, Size? size = null, TimeSpan? captureTime = null)
+        public static bool Snapshot(IMediaAnalysis source, string output, Size? size = null, TimeSpan? captureTime = null)
         {
             if (Path.GetExtension(output) != FileExtension.Png)
                 output = Path.GetFileNameWithoutExtension(output) + FileExtension.Png;
@@ -40,7 +40,7 @@ namespace FFMpegCore
         /// <param name="captureTime">Seek position where the thumbnail should be taken.</param>
         /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
         /// <returns>Bitmap with the requested snapshot.</returns>
-        public static Task<bool> SnapshotAsync(MediaAnalysis source, string output, Size? size = null, TimeSpan? captureTime = null)
+        public static Task<bool> SnapshotAsync(IMediaAnalysis source, string output, Size? size = null, TimeSpan? captureTime = null)
         {
             if (Path.GetExtension(output) != FileExtension.Png)
                 output = Path.GetFileNameWithoutExtension(output) + FileExtension.Png;
@@ -58,7 +58,7 @@ namespace FFMpegCore
         /// <param name="captureTime">Seek position where the thumbnail should be taken.</param>
         /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
         /// <returns>Bitmap with the requested snapshot.</returns>
-        public static Bitmap Snapshot(MediaAnalysis source, Size? size = null, TimeSpan? captureTime = null)
+        public static Bitmap Snapshot(IMediaAnalysis source, Size? size = null, TimeSpan? captureTime = null)
         {
             var arguments = BuildSnapshotArguments(source, size, captureTime);
             using var ms = new MemoryStream();
@@ -78,7 +78,7 @@ namespace FFMpegCore
         /// <param name="captureTime">Seek position where the thumbnail should be taken.</param>
         /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
         /// <returns>Bitmap with the requested snapshot.</returns>
-        public static async Task<Bitmap> SnapshotAsync(MediaAnalysis source, Size? size = null, TimeSpan? captureTime = null)
+        public static async Task<Bitmap> SnapshotAsync(IMediaAnalysis source, Size? size = null, TimeSpan? captureTime = null)
         {
             var arguments = BuildSnapshotArguments(source, size, captureTime);
             using var ms = new MemoryStream();
@@ -92,7 +92,7 @@ namespace FFMpegCore
             return new Bitmap(ms);
         }
 
-        private static FFMpegArguments BuildSnapshotArguments(MediaAnalysis source, Size? size = null, TimeSpan? captureTime = null)
+        private static FFMpegArguments BuildSnapshotArguments(IMediaAnalysis source, Size? size = null, TimeSpan? captureTime = null)
         {
             captureTime ??= TimeSpan.FromSeconds(source.Duration.TotalSeconds / 3);
             size = PrepareSnapshotSize(source, size);
@@ -104,7 +104,7 @@ namespace FFMpegCore
                 .Resize(size);
         }
 
-        private static Size? PrepareSnapshotSize(MediaAnalysis source, Size? wantedSize)
+        private static Size? PrepareSnapshotSize(IMediaAnalysis source, Size? wantedSize)
         {
             if (wantedSize == null || (wantedSize.Value.Height <= 0 && wantedSize.Value.Width <= 0))
                 return null;
@@ -143,7 +143,7 @@ namespace FFMpegCore
         /// <param name="multithreaded">Is encoding multithreaded.</param>
         /// <returns>Output video information.</returns>
         public static bool Convert(
-            MediaAnalysis source,
+            IMediaAnalysis source,
             string output,
             ContainerFormat format,
             Speed speed = Speed.SuperFast,
@@ -235,7 +235,7 @@ namespace FFMpegCore
         /// <param name="output">Output video file.</param>
         /// <param name="videos">List of vides that need to be joined together.</param>
         /// <returns>Output video information.</returns>
-        public static bool Join(string output, params MediaAnalysis[] videos)
+        public static bool Join(string output, params IMediaAnalysis[] videos)
         {
             var temporaryVideoParts = videos.Select(video =>
             {

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -11,13 +11,13 @@ namespace FFMpegCore
 {
     public static class FFProbe
     {
-        public static MediaAnalysis Analyse(string filePath, int outputCapacity = int.MaxValue)
+        public static IMediaAnalysis Analyse(string filePath, int outputCapacity = int.MaxValue)
         {
             using var instance = PrepareInstance(filePath, outputCapacity);
             instance.BlockUntilFinished();
             return ParseOutput(filePath, instance);
         }
-        public static MediaAnalysis Analyse(System.IO.Stream stream, int outputCapacity = int.MaxValue)
+        public static IMediaAnalysis Analyse(System.IO.Stream stream, int outputCapacity = int.MaxValue)
         {
             var streamPipeSource = new StreamPipeSource(stream);
             var pipeArgument = new InputPipeArgument(streamPipeSource);
@@ -40,13 +40,13 @@ namespace FFMpegCore
             
             return ParseOutput(pipeArgument.PipePath, instance);
         }
-        public static async Task<MediaAnalysis> AnalyseAsync(string filePath, int outputCapacity = int.MaxValue)
+        public static async Task<IMediaAnalysis> AnalyseAsync(string filePath, int outputCapacity = int.MaxValue)
         {
             using var instance = PrepareInstance(filePath, outputCapacity);
             await instance.FinishedRunning();
             return ParseOutput(filePath, instance);
         }
-        public static async Task<MediaAnalysis> AnalyseAsync(System.IO.Stream stream, int outputCapacity = int.MaxValue)
+        public static async Task<IMediaAnalysis> AnalyseAsync(System.IO.Stream stream, int outputCapacity = int.MaxValue)
         {
             var streamPipeSource = new StreamPipeSource(stream);
             var pipeArgument = new InputPipeArgument(streamPipeSource);
@@ -73,7 +73,7 @@ namespace FFMpegCore
             return ParseOutput(pipeArgument.PipePath, instance);
         }
 
-        private static MediaAnalysis ParseOutput(string filePath, Instance instance)
+        private static IMediaAnalysis ParseOutput(string filePath, Instance instance)
         {
             var json = string.Join(string.Empty, instance.OutputData);
             var ffprobeAnalysis = JsonSerializer.Deserialize<FFProbeAnalysis>(json, new JsonSerializerOptions

--- a/FFMpegCore/FFProbe/IMediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/IMediaAnalysis.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FFMpegCore
+{
+    public interface IMediaAnalysis
+    {
+        string Path { get; }
+        string Extension { get; }
+        TimeSpan Duration { get; }
+        MediaFormat Format { get; }
+        AudioStream PrimaryAudioStream { get; }
+        VideoStream PrimaryVideoStream { get; }
+        List<VideoStream> VideoStreams { get; }
+        List<AudioStream> AudioStreams { get; }
+    }
+}

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace FFMpegCore
 {
-    public class MediaAnalysis : IMediaAnalysis
+    internal class MediaAnalysis : IMediaAnalysis
     {
         private static readonly Regex DurationRegex = new Regex("^(\\d{1,2}:\\d{1,2}:\\d{1,2}(.\\d{1,7})?)", RegexOptions.Compiled);
         internal MediaAnalysis(string path, FFProbeAnalysis analysis)

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace FFMpegCore
 {
-    public class MediaAnalysis
+    public class MediaAnalysis : IMediaAnalysis
     {
         private static readonly Regex DurationRegex = new Regex("^(\\d{1,2}:\\d{1,2}:\\d{1,2}(.\\d{1,7})?)", RegexOptions.Compiled);
         internal MediaAnalysis(string path, FFProbeAnalysis analysis)

--- a/FFMpegCore/Helpers/FFMpegHelper.cs
+++ b/FFMpegCore/Helpers/FFMpegHelper.cs
@@ -12,7 +12,7 @@ namespace FFMpegCore.Helpers
             ConversionSizeExceptionCheck(image.Size);
         }
 
-        public static void ConversionSizeExceptionCheck(MediaAnalysis info)
+        public static void ConversionSizeExceptionCheck(IMediaAnalysis info)
         {
             ConversionSizeExceptionCheck(new Size(info.PrimaryVideoStream.Width, info.PrimaryVideoStream.Height));
         }


### PR DESCRIPTION
The `MediaAnalysis` class doesn't have a public constructor which makes it hard to mock in applications that use FFMpegCore.

This PR will introduce an interface contract that will enable FFProbe results to be mocked easily in projects that use this package.

_fyi: I couldn't successfully run the unit tests locally after I forked from this repository_