### PR TITLE
Support specifying output encoding for ffmpeg and ffprobe output

### DIFF
--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -130,7 +130,14 @@ namespace FFMpegCore
         {
             FFMpegHelper.RootExceptionCheck();
             FFMpegHelper.VerifyFFMpegExists();
-            var instance = new Instance(FFMpegOptions.Options.FFmpegBinary(), _ffMpegArguments.Text);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = FFMpegOptions.Options.FFmpegBinary(),
+                Arguments = _ffMpegArguments.Text,
+                StandardOutputEncoding = FFMpegOptions.Options.Encoding,
+                StandardErrorEncoding = FFMpegOptions.Options.Encoding,
+            };
+            var instance = new Instance(startInfo);
             cancellationTokenSource = new CancellationTokenSource();
 
             if (_onTimeProgress != null || (_onPercentageProgress != null && _totalTimespan != null))

--- a/FFMpegCore/FFMpeg/FFMpegOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 
 namespace FFMpegCore
@@ -48,6 +49,7 @@ namespace FFMpegCore
         public Dictionary<string, string> ExtensionOverrides { get; private set; } = new Dictionary<string, string>();
 
         public bool UseCache { get; set; } = true;
+        public Encoding Encoding { get; set; } = Encoding.Default;
 
         private static string FFBinary(string name)
         {


### PR DESCRIPTION
Fixes #129 by allowing for providing the encoding to use for parsing the output