### PR TITLE
Add InputDeviceArgument

### DIFF
--- a/FFMpegCore/FFMpeg/Arguments/InputDeviceArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/InputDeviceArgument.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace FFMpegCore.Arguments
+{
+    /// <summary>
+    /// Represents an input device parameter
+    /// </summary>
+    public class InputDeviceArgument : IInputArgument
+    {
+        private readonly string Device;
+
+        public InputDeviceArgument(string device)
+        {
+            Device = device;
+        }
+
+        public Task During(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void Pre() { }
+
+        public void Post() { }
+
+        public string Text => $"-i {Device}";
+    }
+}

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -23,6 +23,7 @@ namespace FFMpegCore
         public static FFMpegArguments FromFileInput(FileInfo fileInfo, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputArgument(fileInfo.FullName, false), addArguments);
         public static FFMpegArguments FromFileInput(IMediaAnalysis mediaAnalysis, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputArgument(mediaAnalysis.Path, false), addArguments);
         public static FFMpegArguments FromUrlInput(Uri uri, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputArgument(uri.AbsoluteUri, false), addArguments);
+        public static FFMpegArguments FromDeviceInput(string device, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputDeviceArgument(device), addArguments);
         public static FFMpegArguments FromPipeInput(IPipeSource sourcePipe, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputPipeArgument(sourcePipe), addArguments);
 
         


### PR DESCRIPTION
Allow device input, such as capture cards, webcams or desktop capture.

## Sample usage :
DirectShow
```cs
FFMpegArguments.FromDeviceInput("video=\"Camera\":audio=\"Microphone\"", args => 
    args.ForceFormat("dshow"))
```