### PR TITLE
Add OutputStreamArgument

### DIFF
--- a/FFMpegCore/FFMpeg/Arguments/OutputStreamArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/OutputStreamArgument.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace FFMpegCore.Arguments
+{
+    /// <summary>
+    /// Represents output stream parameter
+    /// </summary>
+    public class OutputStreamArgument : IOutputArgument
+    {
+        public readonly string Stream;
+
+        public OutputStreamArgument(string stream)
+        {
+            Stream = stream;
+        }
+
+        public void Post() { }
+
+        public Task During(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void Pre() { }
+
+        public string Text => Stream;
+    }
+}

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -51,6 +51,8 @@ namespace FFMpegCore
 
         public FFMpegArgumentProcessor OutputToFile(string file, bool overwrite = true, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputArgument(file, overwrite), addArguments);
         public FFMpegArgumentProcessor OutputToFile(Uri uri, bool overwrite = true, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputArgument(uri.AbsolutePath, overwrite), addArguments);
+        public FFMpegArgumentProcessor OutputToStream(string uri, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputStreamArgument(uri), addArguments);
+        public FFMpegArgumentProcessor OutputToStream(Uri uri, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputStreamArgument(uri.ToString()), addArguments);
         public FFMpegArgumentProcessor OutputToPipe(IPipeSink reader, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputPipeArgument(reader), addArguments);
 
         private FFMpegArgumentProcessor ToProcessor(IOutputArgument argument, Action<FFMpegArgumentOptions>? addArguments)


### PR DESCRIPTION
Properly handles uris and avoids `overwrite: true` which don't make sense with streams.

### Sample usage
```cs
FFMpegArguments.FromDeviceInput("video=\"Camera\":audio=\"Microphone\"", args => args.ForceFormat("dshow"))
                .OutputToStream("rtmp://server/app/your-stream-key", options => options
                    .WithVideoCodec(FFMpeg.GetCodec("h264_qsv"))
                    .WithSpeedPreset(Speed.Fast)
                    .WithVideoBitrate(4000)
                    .WithCustomArgument("-profile high")
                    .WithCustomArgument("-bufsize 8000k")
                    .WithCustomArgument("-g 50")
                    .WithAudioCodec(AudioCodec.Aac)
                    .WithAudioBitrate(128)
                    .WithAudioSamplingRate(44100)
                    .ForceFormat("flv"))
                .ProcessAsynchronously();
```