### PR TITLE
Allow to create empty arguments

### DIFF
--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -375,5 +375,19 @@ namespace FFMpegCore.Test
                 .OutputToFile("output.mp4", false, opt => opt.ForcePixelFormat("yuv444p")).Arguments;
             Assert.AreEqual("-i \"input.mp4\" -pix_fmt yuv444p \"output.mp4\"", str);
         }
+		
+		[TestMethod]
+		public void Builder_BuildEmptyString_FromEmpty()
+		{
+			var str = FFMpegArguments.FromEmpty().OutputToFile("", false).Arguments;
+			Assert.AreEqual("\"\"", str);
+		}
+
+		[TestMethod]
+		public void Builder_BuildLoop_FromEmpty()
+		{
+			var str = FFMpegArguments.FromEmpty(options => options.Loop(1)).OutputToFile("", false).Arguments;
+			Assert.AreEqual("-loop 1 \"\"", str);
+		}
     }
 }

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -16,7 +16,8 @@ namespace FFMpegCore
         private FFMpegArguments() { }
 
         public string Text => string.Join(" ", _globalArguments.Arguments.Concat(Arguments).Select(arg => arg.Text));
-
+        
+	    public static FFMpegArguments FromEmpty(Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithArguments(addArguments);
         public static FFMpegArguments FromConcatInput(IEnumerable<string> filePaths, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new ConcatArgument(filePaths), addArguments);
         public static FFMpegArguments FromDemuxConcatInput(IEnumerable<string> filePaths, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new DemuxConcatArgument(filePaths), addArguments);
         public static FFMpegArguments FromFileInput(string filePath, bool verifyExists = true, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputArgument(verifyExists, filePath), addArguments);
@@ -47,7 +48,15 @@ namespace FFMpegCore
             Arguments.Add(inputArgument);
             return this;
         }
-
+        
+        private FFMpegArguments WithArguments(Action<FFMpegArgumentOptions>? addArguments)
+		{
+			var arguments = new FFMpegArgumentOptions();
+			addArguments?.Invoke(arguments);
+			Arguments.AddRange(arguments.Arguments);
+			return this;
+		}
+        
         public FFMpegArgumentProcessor OutputToFile(string file, bool overwrite = true, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputArgument(file, overwrite), addArguments);
         public FFMpegArgumentProcessor OutputToUrl(string uri, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputUrlArgument(uri), addArguments);
         public FFMpegArgumentProcessor OutputToUrl(Uri uri, Action<FFMpegArgumentOptions>? addArguments = null) => ToProcessor(new OutputUrlArgument(uri.ToString()), addArguments);


### PR DESCRIPTION
I was in need to create command like 
-loop 1 -i "empty.png" -t 31
and was unable to do so because I have to use some input first. 
So I was getting 
-i "empty.png" -loop 1 -t 31 
instead and that is wrong command, it does not produce video with desired length.

Now I can use it like this

FFMpegArguments.FromEmpty(options => options.Loop(1))
				.AddFileInput("empty.png")
...