### PR TITLE
support specific StandardOutputEncoding & StandardErrorEncoding for ffprobe

### DIFF
--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -117,7 +118,12 @@ namespace FFMpegCore
             FFProbeHelper.RootExceptionCheck();
             FFProbeHelper.VerifyFFProbeExists(ffOptions);
             var arguments = $"-loglevel error -print_format json -show_format -sexagesimal -show_streams \"{filePath}\"";
-            var instance = new Instance(GlobalFFOptions.GetFFProbeBinaryPath(), arguments) {DataBufferCapacity = outputCapacity};
+            var instance = new Instance(new ProcessStartInfo(GlobalFFOptions.GetFFProbeBinaryPath(), arguments)
+                {
+                    StandardOutputEncoding = ffOptions.Encoding,
+                    StandardErrorEncoding = ffOptions.Encoding
+                })
+                { DataBufferCapacity = outputCapacity };
             return instance;
         }
     }

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -117,13 +117,15 @@ namespace FFMpegCore
         {
             FFProbeHelper.RootExceptionCheck();
             FFProbeHelper.VerifyFFProbeExists(ffOptions);
-            var arguments = $"-loglevel error -print_format json -show_format -sexagesimal -show_streams \"{filePath}\"";
-            var instance = new Instance(new ProcessStartInfo(GlobalFFOptions.GetFFProbeBinaryPath(), arguments)
-                {
-                    StandardOutputEncoding = ffOptions.Encoding,
-                    StandardErrorEncoding = ffOptions.Encoding
-                })
-                { DataBufferCapacity = outputCapacity };
+            var arguments =
+                $"-loglevel error -print_format json -show_format -sexagesimal -show_streams \"{filePath}\"";
+            var startInfo = new ProcessStartInfo(GlobalFFOptions.GetFFProbeBinaryPath(), arguments)
+            {
+                StandardOutputEncoding = ffOptions.Encoding,
+                StandardErrorEncoding = ffOptions.Encoding
+            };
+            var instance = new Instance(startInfo)
+                {DataBufferCapacity = outputCapacity};
             return instance;
         }
     }


### PR DESCRIPTION
#143 it's seems only specify encoding for ffmpeg

add custom-encoding support for ffprobe