### PR TITLE
Get extra disposition data in MediaStream

### DIFF
--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -120,8 +120,9 @@ namespace FFMpegCore.Test
         {
             var info = await FFProbe.AnalyseAsync(TestResources.Mp4Video);
             Assert.IsNotNull(info.PrimaryAudioStream);
-            Assert.AreEqual(1, info.PrimaryAudioStream.Disposition["default"]);
-            Assert.AreEqual(0, info.PrimaryAudioStream.Disposition["forced"]);
+            Assert.IsNotNull(info.PrimaryAudioStream.Disposition);
+            Assert.AreEqual(true, info.PrimaryAudioStream.Disposition["default"]);
+            Assert.AreEqual(false, info.PrimaryAudioStream.Disposition["forced"]);
         }
     }
 }

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -114,5 +114,14 @@ namespace FFMpegCore.Test
             Assert.AreEqual(0, info.AudioStreams.Count);
             Assert.AreEqual(0, info.VideoStreams.Count);
         }
+
+        [TestMethod, Timeout(10000)]
+        public async Task Probe_Success_Disposition_Async()
+        {
+            var info = await FFProbe.AnalyseAsync(TestResources.Mp4Video);
+            Assert.IsNotNull(info.PrimaryAudioStream);
+            Assert.AreEqual(1, info.PrimaryAudioStream.Disposition["default"]);
+            Assert.AreEqual(0, info.PrimaryAudioStream.Disposition["forced"]);
+        }
     }
 }

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -12,7 +12,7 @@ namespace FFMpegCore
         public Format Format { get; set; } = null!;
     }
     
-    public class FFProbeStream : ITagsContainer
+    public class FFProbeStream : ITagsContainer, IDispositionContainer
     {
         [JsonPropertyName("index")]
         public int Index { get; set; }
@@ -71,9 +71,13 @@ namespace FFMpegCore
         [JsonPropertyName("sample_rate")]
         public string SampleRate { get; set; } = null!;
 
+        [JsonPropertyName("disposition")]
+        public Dictionary<string, int> Disposition { get; set; } = null!;
+
         [JsonPropertyName("tags")]
         public Dictionary<string, string> Tags { get; set; } = null!;
     }
+
     public class Format : ITagsContainer
     {
         [JsonPropertyName("filename")]
@@ -110,10 +114,16 @@ namespace FFMpegCore
         public Dictionary<string, string> Tags { get; set; } = null!;
     }
 
+    public interface IDispositionContainer
+    {
+        Dictionary<string, int> Disposition { get; set; }
+    }
+
     public interface ITagsContainer
     {
         Dictionary<string, string> Tags { get; set; }
     }
+
     public static class TagExtensions
     {
         private static string? TryGetTagValue(ITagsContainer tagsContainer, string key)
@@ -127,7 +137,18 @@ namespace FFMpegCore
         public static string? GetCreationTime(this ITagsContainer tagsContainer) => TryGetTagValue(tagsContainer, "creation_time ");
         public static string? GetRotate(this ITagsContainer tagsContainer) => TryGetTagValue(tagsContainer, "rotate");
         public static string? GetDuration(this ITagsContainer tagsContainer) => TryGetTagValue(tagsContainer, "duration");
-        
-        
+    }
+
+    public static class DispositionExtensions
+    {
+        private static int? TryGetDispositionValue(IDispositionContainer dispositionContainer, string key)
+        {
+            if (dispositionContainer.Disposition != null && dispositionContainer.Disposition.TryGetValue(key, out var dispositionValue))
+                return dispositionValue;
+            return null;
+        }
+
+        public static int? GetDefault(this IDispositionContainer tagsContainer) => TryGetDispositionValue(tagsContainer, "default");
+        public static int? GetForced(this IDispositionContainer tagsContainer) => TryGetDispositionValue(tagsContainer, "forced");
     }
 }

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -67,6 +67,7 @@ namespace FFMpegCore
                 PixelFormat = stream.PixelFormat,
                 Rotation = (int)float.Parse(stream.GetRotate() ?? "0"),
                 Language = stream.GetLanguage(),
+                Disposition = stream.Disposition,
                 Tags = stream.Tags,
             };
         }
@@ -87,6 +88,7 @@ namespace FFMpegCore
                 SampleRateHz = !string.IsNullOrEmpty(stream.SampleRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.SampleRate) : default,
                 Profile = stream.Profile,
                 Language = stream.GetLanguage(),
+                Disposition = stream.Disposition,
                 Tags = stream.Tags,
             };
         }
@@ -101,6 +103,7 @@ namespace FFMpegCore
                 CodecLongName = stream.CodecLongName,
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
                 Language = stream.GetLanguage(),
+                Disposition = stream.Disposition,
                 Tags = stream.Tags,
             };
         }

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -67,7 +67,7 @@ namespace FFMpegCore
                 PixelFormat = stream.PixelFormat,
                 Rotation = (int)float.Parse(stream.GetRotate() ?? "0"),
                 Language = stream.GetLanguage(),
-                Disposition = stream.Disposition,
+                Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
                 Tags = stream.Tags,
             };
         }
@@ -88,7 +88,7 @@ namespace FFMpegCore
                 SampleRateHz = !string.IsNullOrEmpty(stream.SampleRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.SampleRate) : default,
                 Profile = stream.Profile,
                 Language = stream.GetLanguage(),
-                Disposition = stream.Disposition,
+                Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
                 Tags = stream.Tags,
             };
         }
@@ -103,7 +103,7 @@ namespace FFMpegCore
                 CodecLongName = stream.CodecLongName,
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
                 Language = stream.GetLanguage(),
-                Disposition = stream.Disposition,
+                Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
                 Tags = stream.Tags,
             };
         }
@@ -171,6 +171,31 @@ namespace FFMpegCore
         public static TimeSpan ParseDuration(FFProbeStream ffProbeStream)
         {
             return ParseDuration(ffProbeStream.Duration);
+        }
+
+        public static Dictionary<string, bool>? FormatDisposition(Dictionary<string, int>? disposition)
+        {
+            if (disposition == null)
+            {
+                return null;
+            }
+
+            var result = new Dictionary<string, bool>(disposition.Count);
+
+            foreach (var pair in disposition)
+            {
+                result.Add(pair.Key, ToBool(pair.Value));
+            }
+
+            static bool ToBool(int value) => value switch
+            {
+                0 => false,
+                1 => true,
+                _ => throw new ArgumentOutOfRangeException(nameof(value),
+                    $"Not expected disposition state value: {value}")
+            };
+
+            return result;
         }
     }
 }

--- a/FFMpegCore/FFProbe/MediaStream.cs
+++ b/FFMpegCore/FFProbe/MediaStream.cs
@@ -15,8 +15,9 @@ namespace FFMpegCore
         public int BitRate { get; internal set; }
         public TimeSpan Duration { get; internal set; }
         public string? Language { get; internal set; }
+        public Dictionary<string, int>? Disposition { get; internal set; }
         public Dictionary<string, string>? Tags { get; internal set; }
-
+        
         public Codec GetCodecInfo() => FFMpeg.GetCodec(CodecName);
     }
 }

--- a/FFMpegCore/FFProbe/MediaStream.cs
+++ b/FFMpegCore/FFProbe/MediaStream.cs
@@ -15,7 +15,7 @@ namespace FFMpegCore
         public int BitRate { get; internal set; }
         public TimeSpan Duration { get; internal set; }
         public string? Language { get; internal set; }
-        public Dictionary<string, int>? Disposition { get; internal set; }
+        public Dictionary<string, bool>? Disposition { get; internal set; }
         public Dictionary<string, string>? Tags { get; internal set; }
         
         public Codec GetCodecInfo() => FFMpeg.GetCodec(CodecName);


### PR DESCRIPTION
Gets disposition data from media stream. Useful, but not limited, to know when an stream is marked as default or forced