### PR TITLE
fix stream index for passing to ffmpeg while making a snapshot

### DIFF
--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -116,12 +116,9 @@ namespace FFMpegCore
         {
             captureTime ??= TimeSpan.FromSeconds(source.Duration.TotalSeconds / 3);
             size = PrepareSnapshotSize(source, size);
-            if (streamIndex == null)
-            {
-                streamIndex = source.PrimaryVideoStream?.Index
-                    ?? source.VideoStreams.First()?.Index
-                    ?? 0;
-            }
+            streamIndex ??= source.PrimaryVideoStream?.Index
+                            ?? source.VideoStreams.FirstOrDefault()?.Index
+                            ?? 0;
 
             return (FFMpegArguments
                 .FromFileInput(input, false, options => options

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -116,7 +116,12 @@ namespace FFMpegCore
         {
             captureTime ??= TimeSpan.FromSeconds(source.Duration.TotalSeconds / 3);
             size = PrepareSnapshotSize(source, size);
-            streamIndex = streamIndex == null ? 0 : source.VideoStreams.FirstOrDefault(videoStream => videoStream.Index == streamIndex).Index;
+            if (streamIndex == null)
+            {
+                streamIndex = source.PrimaryVideoStream?.Index
+                    ?? source.VideoStreams.First()?.Index
+                    ?? 0;
+            }
 
             return (FFMpegArguments
                 .FromFileInput(input, false, options => options


### PR DESCRIPTION
Caught an error using SnapshotAsync with default null value for streamIndex param: streamIndex was zero in all cases, neglecting info gathered about video file. In failed case audio stream had index 0 and video stream had index 1, so mapping from 0:0 was wrong. This fix helps to avoid such situations