### PR TITLE
Change Int32 to long for BitRate

### DIFF
--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -52,7 +52,7 @@ namespace FFMpegCore
             {
                 Index = stream.Index,
                 AvgFrameRate = MediaAnalysisUtils.DivideRatio(MediaAnalysisUtils.ParseRatioDouble(stream.AvgFrameRate, '/')),
-                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitRate) : default,
+                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseLongInvariant(stream.BitRate) : default,
                 BitsPerRawSample = !string.IsNullOrEmpty(stream.BitsPerRawSample) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitsPerRawSample) : default,
                 CodecName = stream.CodecName,
                 CodecLongName = stream.CodecLongName,
@@ -77,7 +77,7 @@ namespace FFMpegCore
             return new AudioStream
             {
                 Index = stream.Index,
-                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitRate) : default,
+                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseLongInvariant(stream.BitRate) : default,
                 CodecName = stream.CodecName,
                 CodecLongName = stream.CodecLongName,
                 CodecTag = stream.CodecTag,
@@ -98,7 +98,7 @@ namespace FFMpegCore
             return new SubtitleStream
             {
                 Index = stream.Index,
-                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitRate) : default,
+                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseLongInvariant(stream.BitRate) : default,
                 CodecName = stream.CodecName,
                 CodecLongName = stream.CodecLongName,
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
@@ -134,6 +134,9 @@ namespace FFMpegCore
 
         public static int ParseIntInvariant(string line) =>
             int.Parse(line, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture);
+        
+        public static long ParseLongInvariant(string line) =>
+            long.Parse(line, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture);
         
         
         public static TimeSpan ParseDuration(string duration)

--- a/FFMpegCore/FFProbe/MediaStream.cs
+++ b/FFMpegCore/FFProbe/MediaStream.cs
@@ -12,7 +12,7 @@ namespace FFMpegCore
         public string CodecLongName { get; internal set; } = null!;
         public string CodecTagString { get; set; } = null!;
         public string CodecTag { get; set; } = null!;
-        public int BitRate { get; internal set; }
+        public long BitRate { get; internal set; }
         public TimeSpan Duration { get; internal set; }
         public string? Language { get; internal set; }
         public Dictionary<string, bool>? Disposition { get; internal set; }


### PR DESCRIPTION
When parsing a weird ffprobe json output we get an exception parsing bitrate
Note that `bit_rate` value is close to UInt32 max value

```
{
    "streams": [
        {
            "index": 0,
            "codec_name": "vorbis",
            "codec_long_name": "Vorbis",
            "codec_type": "audio",
            "codec_tag_string": "[0][0][0][0]",
            "codec_tag": "0x0000",
            "sample_fmt": "fltp",
            "sample_rate": "96000",
            "channels": 2,
            "channel_layout": "stereo",
            "bits_per_sample": 0,
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/96000",
            "start_pts": 0,
            "start_time": "0.000000",
            "duration_ts": 44403,
            "duration": "0.462531",
            "bit_rate": "4294967294",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0
            }
        }
    ]
}
```