### PR TITLE
V.4.6.0

### DIFF
--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -447,5 +447,27 @@ namespace FFMpegCore.Test
 
             Assert.AreEqual("-i \"input.mp4\" -af \"pan=stereo\" \"output.mp4\"", str);
         }
+
+        [TestMethod]
+        public void Builder_BuildString_DynamicAudioNormalizerDefaultFormat()
+        {
+            var str = FFMpegArguments.FromFileInput("input.mp4")
+                .OutputToFile("output.mp4", false,
+                    opt => opt.WithAudioFilters(filterOptions => filterOptions.DynamicNormalizer()))
+                .Arguments;
+
+            Assert.AreEqual("-i \"input.mp4\" -af \"dynaudnorm=f=500:g=31:p=0.95:m=10.0:r=0.0:n=1:c=0:b=0:s=0.0\" \"output.mp4\"", str);
+        }
+
+        [TestMethod]
+        public void Builder_BuildString_DynamicAudioNormalizerWithValuesFormat()
+        {
+            var str = FFMpegArguments.FromFileInput("input.mp4")
+                .OutputToFile("output.mp4", false,
+                    opt => opt.WithAudioFilters(filterOptions => filterOptions.DynamicNormalizer(125, 13, 0.9215, 5.124, 0.5458,false,true,true, 0.3333333)))
+                .Arguments;
+
+            Assert.AreEqual("-i \"input.mp4\" -af \"dynaudnorm=f=125:g=13:p=0.92:m=5.1:r=0.5:n=0:c=1:b=1:s=0.3\" \"output.mp4\"", str);
+        }
     }
 }

--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -414,5 +414,38 @@ namespace FFMpegCore.Test
                 .OutputToFile("output.mp4", false, opt => opt.ForcePixelFormat("yuv444p")).Arguments;
             Assert.AreEqual("-i \"input.mp4\" -pix_fmt yuv444p \"output.mp4\"", str);
         }
+
+        [TestMethod]
+        public void Builder_BuildString_PanAudioFilterChannelNumber()
+        {
+            var str = FFMpegArguments.FromFileInput("input.mp4")
+                .OutputToFile("output.mp4", false,
+                    opt => opt.WithAudioFilters(filterOptions => filterOptions.Pan(2, "c0=c1", "c1=c1")))
+                .Arguments;
+
+            Assert.AreEqual("-i \"input.mp4\" -af \"pan=2c|c0=c1|c1=c1\" \"output.mp4\"", str);
+        }
+
+        [TestMethod]
+        public void Builder_BuildString_PanAudioFilterChannelLayout()
+        {
+            var str = FFMpegArguments.FromFileInput("input.mp4")
+                .OutputToFile("output.mp4", false,
+                    opt => opt.WithAudioFilters(filterOptions => filterOptions.Pan("stereo", "c0=c0", "c1=c1")))
+                .Arguments;
+
+            Assert.AreEqual("-i \"input.mp4\" -af \"pan=stereo|c0=c0|c1=c1\" \"output.mp4\"", str);
+        }
+
+        [TestMethod]
+        public void Builder_BuildString_PanAudioFilterChannelNoOutputDefinition()
+        {
+            var str = FFMpegArguments.FromFileInput("input.mp4")
+                .OutputToFile("output.mp4", false,
+                    opt => opt.WithAudioFilters(filterOptions => filterOptions.Pan("stereo")))
+                .Arguments;
+
+            Assert.AreEqual("-i \"input.mp4\" -af \"pan=stereo\" \"output.mp4\"", str);
+        }
     }
 }

--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -341,7 +341,22 @@ namespace FFMpegCore.Test
                                 .WithParameter("PrimaryColour", "&HAA00FF00")))))
                 .Arguments;
 
-            Assert.AreEqual("-i \"input.mp4\" -vf \"subtitles=sample.srt:charenc=UTF-8:original_size=1366x768:stream_index=0:force_style='FontName=DejaVu Serif\\,PrimaryColour=&HAA00FF00'\" \"output.mp4\"",
+            Assert.AreEqual("-i \"input.mp4\" -vf \"subtitles='sample.srt':charenc=UTF-8:original_size=1366x768:stream_index=0:force_style='FontName=DejaVu Serif\\,PrimaryColour=&HAA00FF00'\" \"output.mp4\"",
+                str);
+        }
+
+        [TestMethod]
+        public void Builder_BuildString_SubtitleHardBurnFilterFixedPaths()
+        {
+            var str = FFMpegArguments
+                .FromFileInput("input.mp4")
+                .OutputToFile("output.mp4", false, opt => opt
+                    .WithVideoFilters(filterOptions => filterOptions
+                        .HardBurnSubtitle(SubtitleHardBurnOptions
+                            .Create(subtitlePath: @"sample( \ : [ ] , ).srt"))))
+                .Arguments;
+
+            Assert.AreEqual(@"-i ""input.mp4"" -vf ""subtitles='sample( \\ \: \[ \] \, ).srt'"" ""output.mp4""",
                 str);
         }
 

--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -353,10 +353,10 @@ namespace FFMpegCore.Test
                 .OutputToFile("output.mp4", false, opt => opt
                     .WithVideoFilters(filterOptions => filterOptions
                         .HardBurnSubtitle(SubtitleHardBurnOptions
-                            .Create(subtitlePath: @"sample( \ : [ ] , ).srt"))))
+                            .Create(subtitlePath: @"sample( \ : [ ] , ' ).srt"))))
                 .Arguments;
 
-            Assert.AreEqual(@"-i ""input.mp4"" -vf ""subtitles='sample( \\ \: \[ \] \, ).srt'"" ""output.mp4""",
+            Assert.AreEqual(@"-i ""input.mp4"" -vf ""subtitles='sample( \\ \: \[ \] \, '\\\'' ).srt'"" ""output.mp4""",
                 str);
         }
 

--- a/FFMpegCore.Test/AudioTest.cs
+++ b/FFMpegCore.Test/AudioTest.cs
@@ -229,7 +229,7 @@ namespace FFMpegCore.Test
         {
             using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
-            var success = FFMpegArguments.FromFileInput(TestResources.Mp4Video)
+            var success = FFMpegArguments.FromFileInput(TestResources.Mp3Audio)
                 .OutputToFile(outputFile, true,
                     argumentOptions => argumentOptions
                         .WithAudioFilters(filter => filter.Pan(1, "c0 < 0.9 * c0 + 0.1 * c1")))
@@ -246,7 +246,7 @@ namespace FFMpegCore.Test
         {
             using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
-            var success = FFMpegArguments.FromFileInput(TestResources.Mp4Video)
+            var success = FFMpegArguments.FromFileInput(TestResources.Mp3Audio)
                 .OutputToFile(outputFile, true,
                     argumentOptions => argumentOptions
                         .WithAudioFilters(filter => filter.Pan(1)))
@@ -263,7 +263,7 @@ namespace FFMpegCore.Test
         {
             using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
-            var ex = Assert.ThrowsException<ArgumentException>(() => FFMpegArguments.FromFileInput(TestResources.Mp4Video)
+            var ex = Assert.ThrowsException<ArgumentException>(() => FFMpegArguments.FromFileInput(TestResources.Mp3Audio)
                 .OutputToFile(outputFile, true,
                     argumentOptions => argumentOptions
                         .WithAudioFilters(filter => filter.Pan(1, "c0=c0", "c1=c1")))
@@ -275,7 +275,7 @@ namespace FFMpegCore.Test
         {
             using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
-            var ex = Assert.ThrowsException<FFMpegException>(() => FFMpegArguments.FromFileInput(TestResources.Mp4Video)
+            var ex = Assert.ThrowsException<FFMpegException>(() => FFMpegArguments.FromFileInput(TestResources.Mp3Audio)
                 .OutputToFile(outputFile, true,
                     argumentOptions => argumentOptions
                         .WithAudioFilters(filter => filter.Pan("mono", "c0=c0", "c1=c1")))

--- a/FFMpegCore.Test/AudioTest.cs
+++ b/FFMpegCore.Test/AudioTest.cs
@@ -239,6 +239,7 @@ namespace FFMpegCore.Test
 
             Assert.IsTrue(success);
             Assert.AreEqual(1, mediaAnalysis.AudioStreams.Count);
+            Assert.AreEqual("mono", mediaAnalysis.PrimaryAudioStream.ChannelLayout);
         }
 
         [TestMethod, Timeout(10000)]
@@ -256,6 +257,7 @@ namespace FFMpegCore.Test
 
             Assert.IsTrue(success);
             Assert.AreEqual(1, mediaAnalysis.AudioStreams.Count);
+            Assert.AreEqual("mono", mediaAnalysis.PrimaryAudioStream.ChannelLayout);
         }
 
         [TestMethod, Timeout(10000)]

--- a/FFMpegCore.Test/AudioTest.cs
+++ b/FFMpegCore.Test/AudioTest.cs
@@ -1,5 +1,6 @@
 ﻿using FFMpegCore.Enums;
 using FFMpegCore.Exceptions;
+using FFMpegCore.Extend;
 using FFMpegCore.Pipes;
 using FFMpegCore.Test.Resources;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -8,7 +9,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using FFMpegCore.Extend;
 
 namespace FFMpegCore.Test
 {
@@ -279,6 +279,52 @@ namespace FFMpegCore.Test
                 .OutputToFile(outputFile, true,
                     argumentOptions => argumentOptions
                         .WithAudioFilters(filter => filter.Pan("mono", "c0=c0", "c1=c1")))
+                .ProcessSynchronously());
+        }
+
+        [TestMethod, Timeout(10000)]
+        public void Audio_DynamicNormalizer_WithDefaultValues()
+        {
+            using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
+
+            var success = FFMpegArguments.FromFileInput(TestResources.Mp3Audio)
+                .OutputToFile(outputFile, true,
+                    argumentOptions => argumentOptions
+                        .WithAudioFilters(filter => filter.DynamicNormalizer()))
+                .ProcessSynchronously();
+
+            Assert.IsTrue(success);
+        }
+
+        [TestMethod, Timeout(10000)]
+        public void Audio_DynamicNormalizer_WithNonDefaultValues()
+        {
+            using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
+
+            var success = FFMpegArguments.FromFileInput(TestResources.Mp3Audio)
+                .OutputToFile(outputFile, true,
+                    argumentOptions => argumentOptions
+                        .WithAudioFilters(
+                            filter => filter.DynamicNormalizer(250, 7, 0.9, 2, 1, false, true, true, 0.5)))
+                .ProcessSynchronously();
+
+            Assert.IsTrue(success);
+        }
+
+        [DataTestMethod, Timeout(10000)]
+        [DataRow(2)]
+        [DataRow(32)]
+        [DataRow(8)]
+        public void Audio_DynamicNormalizer_FilterWindow(int filterWindow)
+        {
+            using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
+
+            var ex = Assert.ThrowsException<ArgumentOutOfRangeException>(() => FFMpegArguments
+                .FromFileInput(TestResources.Mp3Audio)
+                .OutputToFile(outputFile, true,
+                    argumentOptions => argumentOptions
+                        .WithAudioFilters(
+                            filter => filter.DynamicNormalizer(filterWindow: filterWindow)))
                 .ProcessSynchronously());
         }
     }

--- a/FFMpegCore.Test/FFMpegCore.Test.csproj
+++ b/FFMpegCore.Test/FFMpegCore.Test.csproj
@@ -40,9 +40,9 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -120,8 +120,9 @@ namespace FFMpegCore.Test
         {
             var info = await FFProbe.AnalyseAsync(TestResources.Mp4Video);
             Assert.IsNotNull(info.PrimaryAudioStream);
-            Assert.AreEqual(1, info.PrimaryAudioStream.Disposition["default"]);
-            Assert.AreEqual(0, info.PrimaryAudioStream.Disposition["forced"]);
+            Assert.IsNotNull(info.PrimaryAudioStream.Disposition);
+            Assert.AreEqual(true, info.PrimaryAudioStream.Disposition["default"]);
+            Assert.AreEqual(false, info.PrimaryAudioStream.Disposition["forced"]);
         }
     }
 }

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FFMpegCore.Test.Resources;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,6 +24,30 @@ namespace FFMpegCore.Test
             await using var inputStream = File.OpenRead(TestResources.WebmVideo);
             var streamAnalysis = await FFProbe.AnalyseAsync(inputStream);
             Assert.IsTrue(fileAnalysis.Duration == streamAnalysis.Duration);
+        }
+
+        [TestMethod]
+        public void FrameAnalysis_Sync()
+        {
+            var frameAnalysis = FFProbe.GetFrames(TestResources.WebmVideo);
+            
+            Assert.AreEqual(90, frameAnalysis.Frames.Count);
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.PixelFormat == "yuv420p"));
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.Height == 360));
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.Width == 640));
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.MediaType == "video"));
+        }
+
+        [TestMethod]
+        public async Task FrameAnalysis_Async()
+        {
+            var frameAnalysis = await FFProbe.GetFramesAsync(TestResources.WebmVideo);
+            
+            Assert.AreEqual(90, frameAnalysis.Frames.Count);
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.PixelFormat == "yuv420p"));
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.Height == 360));
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.Width == 640));
+            Assert.IsTrue(frameAnalysis.Frames.All(f => f.MediaType == "video"));
         }
 
         [DataTestMethod]

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -114,5 +114,14 @@ namespace FFMpegCore.Test
             Assert.AreEqual(0, info.AudioStreams.Count);
             Assert.AreEqual(0, info.VideoStreams.Count);
         }
+
+        [TestMethod, Timeout(10000)]
+        public async Task Probe_Success_Disposition_Async()
+        {
+            var info = await FFProbe.AnalyseAsync(TestResources.Mp4Video);
+            Assert.IsNotNull(info.PrimaryAudioStream);
+            Assert.AreEqual(1, info.PrimaryAudioStream.Disposition["default"]);
+            Assert.AreEqual(0, info.PrimaryAudioStream.Disposition["forced"]);
+        }
     }
 }

--- a/FFMpegCore/Extend/BitmapVideoFrameWrapper.cs
+++ b/FFMpegCore/Extend/BitmapVideoFrameWrapper.cs
@@ -49,7 +49,7 @@ namespace FFMpegCore.Extend
             {
                 var buffer = new byte[data.Stride * data.Height];
                 Marshal.Copy(data.Scan0, buffer, 0, buffer.Length);
-                await stream.WriteAsync(buffer, 0, buffer.Length, token);
+                await stream.WriteAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
             }
             finally
             {

--- a/FFMpegCore/Extend/KeyValuePairExtensions.cs
+++ b/FFMpegCore/Extend/KeyValuePairExtensions.cs
@@ -16,7 +16,7 @@ namespace FFMpegCore.Extend
         public static string FormatArgumentPair(this KeyValuePair<string, string> pair, bool enclose)
         {
             var key = pair.Key;
-            var value = enclose ? pair.Value.EncloseIfContainsSpace() : pair.Value;
+            var value = enclose ? StringExtensions.EncloseIfContainsSpace(pair.Value) : pair.Value;
 
             return $"{key}={value}";
         }

--- a/FFMpegCore/Extend/PcmAudioSampleWrapper.cs
+++ b/FFMpegCore/Extend/PcmAudioSampleWrapper.cs
@@ -24,7 +24,7 @@ namespace FFMpegCore.Extend
 
         public async Task SerializeAsync(Stream stream, CancellationToken token)
         {
-            await stream.WriteAsync(_sample, 0, _sample.Length, token);
+            await stream.WriteAsync(_sample, 0, _sample.Length, token).ConfigureAwait(false);
         }
     }
 }

--- a/FFMpegCore/Extend/StringExtensions.cs
+++ b/FFMpegCore/Extend/StringExtensions.cs
@@ -1,7 +1,19 @@
-﻿namespace FFMpegCore.Extend
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace FFMpegCore.Extend
 {
     internal static class StringExtensions
     {
+        private static Dictionary<char, string> CharactersSubstitution { get; } = new Dictionary<char, string>
+        {
+            {'\\', @"\\"},
+            {':', @"\:"},
+            {'[', @"\["},
+            {']', @"\]"},
+            // {'\'', @"\'"} TODO: Quotes need to be escaped but i failed miserably
+        };
+
         /// <summary>
         ///     Enclose string between quotes if contains an space character
         /// </summary>
@@ -10,6 +22,49 @@
         public static string EncloseIfContainsSpace(this string input)
         {
             return input.Contains(" ") ? $"'{input}'" : input;
+        }
+
+        /// <summary>
+        /// Enclose an string in quotes
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string EncloseInQuotes(this string input)
+        {
+            return $"'{input}'";
+        }
+
+        /// <summary>
+        ///     Scape several characters in subtitle path used by FFmpeg
+        /// </summary>
+        /// <remarks>
+        ///     This is needed because internally FFmpeg use Libav Filters
+        ///     and the info send to it must be in an specific format
+        /// </remarks>
+        /// <param name="source"></param>
+        /// <returns>Scaped path</returns>
+        public static string ToFFmpegLibavfilterPath(this string source)
+        {
+            return source.Replace(CharactersSubstitution);
+        }
+
+        public static string Replace(this string str, Dictionary<char, string> replaceList)
+        {
+            var parsedString = new StringBuilder();
+
+            foreach (var l in str)
+            {
+                if (replaceList.ContainsKey(l))
+                {
+                    parsedString.Append(replaceList[l]);
+                }
+                else
+                {
+                    parsedString.Append(l);
+                }
+            }
+
+            return parsedString.ToString();
         }
     }
 }

--- a/FFMpegCore/Extend/StringExtensions.cs
+++ b/FFMpegCore/Extend/StringExtensions.cs
@@ -7,11 +7,11 @@ namespace FFMpegCore.Extend
     {
         private static Dictionary<char, string> CharactersSubstitution { get; } = new Dictionary<char, string>
         {
-            {'\\', @"\\"},
-            {':', @"\:"},
-            {'[', @"\["},
-            {']', @"\]"},
-            // {'\'', @"\'"} TODO: Quotes need to be escaped but i failed miserably
+            { '\\', @"\\" },
+            { ':', @"\:" },
+            { '[', @"\[" },
+            { ']', @"\]" },
+            { '\'', @"'\\\''" }
         };
 
         /// <summary>

--- a/FFMpegCore/Extend/StringExtensions.cs
+++ b/FFMpegCore/Extend/StringExtensions.cs
@@ -19,7 +19,7 @@ namespace FFMpegCore.Extend
         /// </summary>
         /// <param name="input">The input</param>
         /// <returns>The enclosed string</returns>
-        public static string EncloseIfContainsSpace(this string input)
+        public static string EncloseIfContainsSpace(string input)
         {
             return input.Contains(" ") ? $"'{input}'" : input;
         }
@@ -29,7 +29,7 @@ namespace FFMpegCore.Extend
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
-        public static string EncloseInQuotes(this string input)
+        public static string EncloseInQuotes(string input)
         {
             return $"'{input}'";
         }
@@ -43,7 +43,7 @@ namespace FFMpegCore.Extend
         /// </remarks>
         /// <param name="source"></param>
         /// <returns>Scaped path</returns>
-        public static string ToFFmpegLibavfilterPath(this string source)
+        public static string ToFFmpegLibavfilterPath(string source)
         {
             return source.Replace(CharactersSubstitution);
         }

--- a/FFMpegCore/FFMpeg/Arguments/AudioFiltersArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/AudioFiltersArgument.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using FFMpegCore.Enums;
 using FFMpegCore.Exceptions;
 
 namespace FFMpegCore.Arguments
@@ -43,7 +41,10 @@ namespace FFMpegCore.Arguments
     public class AudioFilterOptions
     {
         public List<IAudioFilterArgument> Arguments { get; } = new List<IAudioFilterArgument>();
-     
+
+        public AudioFilterOptions Pan(string channelLayout, params string[] outputDefinitions) => WithArgument(new PanArgument(channelLayout, outputDefinitions));
+        public AudioFilterOptions Pan(int channels, params string[] outputDefinitions) => WithArgument(new PanArgument(channels, outputDefinitions));
+
         private AudioFilterOptions WithArgument(IAudioFilterArgument argument)
         {
             Arguments.Add(argument);

--- a/FFMpegCore/FFMpeg/Arguments/AudioFiltersArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/AudioFiltersArgument.cs
@@ -44,6 +44,12 @@ namespace FFMpegCore.Arguments
 
         public AudioFilterOptions Pan(string channelLayout, params string[] outputDefinitions) => WithArgument(new PanArgument(channelLayout, outputDefinitions));
         public AudioFilterOptions Pan(int channels, params string[] outputDefinitions) => WithArgument(new PanArgument(channels, outputDefinitions));
+        public AudioFilterOptions DynamicNormalizer(int frameLength = 500, int filterWindow = 31, double targetPeak = 0.95,
+            double gainFactor = 10.0, double targetRms = 0.0, bool channelCoupling = true,
+            bool enableDcBiasCorrection = false, bool enableAlternativeBoundary = false,
+            double compressorFactor = 0.0) => WithArgument(new DynamicNormalizerArgument(frameLength, filterWindow,
+            targetPeak, gainFactor, targetRms, channelCoupling, enableDcBiasCorrection, enableAlternativeBoundary,
+            compressorFactor));
 
         private AudioFilterOptions WithArgument(IAudioFilterArgument argument)
         {

--- a/FFMpegCore/FFMpeg/Arguments/AudioFiltersArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/AudioFiltersArgument.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using FFMpegCore.Enums;
+using FFMpegCore.Exceptions;
+
+namespace FFMpegCore.Arguments
+{
+    public class AudioFiltersArgument : IArgument
+    {
+        public readonly AudioFilterOptions Options;
+
+        public AudioFiltersArgument(AudioFilterOptions options)
+        {
+            Options = options;
+        }
+
+        public string Text => GetText();
+
+        private string GetText()
+        {
+            if (!Options.Arguments.Any())
+                throw new FFMpegArgumentException("No audio-filter arguments provided");
+
+            var arguments = Options.Arguments
+                .Where(arg => !string.IsNullOrEmpty(arg.Value))
+                .Select(arg =>
+                {
+                    var escapedValue = arg.Value.Replace(",", "\\,");
+                    return string.IsNullOrEmpty(arg.Key) ? escapedValue : $"{arg.Key}={escapedValue}";
+                });
+
+            return $"-af \"{string.Join(", ", arguments)}\"";
+        }
+    }
+
+    public interface IAudioFilterArgument
+    {
+        public string Key { get; }
+        public string Value { get; }
+    }
+
+    public class AudioFilterOptions
+    {
+        public List<IAudioFilterArgument> Arguments { get; } = new List<IAudioFilterArgument>();
+     
+        private AudioFilterOptions WithArgument(IAudioFilterArgument argument)
+        {
+            Arguments.Add(argument);
+            return this;
+        }
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/DynamicNormalizerArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/DynamicNormalizerArgument.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace FFMpegCore.Arguments
+{
+    public class DynamicNormalizerArgument : IAudioFilterArgument
+    {
+        private readonly Dictionary<string, string> _arguments = new Dictionary<string, string>();
+
+        /// <summary>
+        ///     Dynamic Audio Normalizer. <see href="https://ffmpeg.org/ffmpeg-filters.html#dynaudnorm"/>
+        /// </summary>
+        /// <param name="frameLength">Set the frame length in milliseconds. Must be between 10 to 8000. The default value is 500</param>
+        /// <param name="filterWindow">Set the Gaussian filter window size. In range from 3 to 301, must be odd number. The default value is 31</param>
+        /// <param name="targetPeak">Set the target peak value. The default value is 0.95</param>
+        /// <param name="gainFactor">Set the maximum gain factor. In range from 1.0 to 100.0. Default is 10.0.</param>
+        /// <param name="targetRms">Set the target RMS. In range from 0.0 to 1.0. Default to 0.0 (disabled)</param>
+        /// <param name="channelCoupling">Enable channels coupling. By default is enabled.</param>
+        /// <param name="enableDcBiasCorrection">Enable DC bias correction. By default is disabled.</param>
+        /// <param name="enableAlternativeBoundary">Enable alternative boundary mode. By default is disabled.</param>
+        /// <param name="compressorFactor">Set the compress factor. In range from 0.0 to 30.0. Default is 0.0 (disabled).</param>
+        public DynamicNormalizerArgument(int frameLength = 500, int filterWindow = 31, double targetPeak = 0.95, double gainFactor = 10.0, double targetRms = 0.0, bool channelCoupling = true, bool enableDcBiasCorrection = false, bool enableAlternativeBoundary = false, double compressorFactor = 0.0)
+        {
+            if (frameLength < 10 || frameLength > 8000) throw new ArgumentOutOfRangeException(nameof(frameLength),"Frame length must be between 10 to 8000");
+            if (filterWindow < 3 || filterWindow > 31) throw new ArgumentOutOfRangeException(nameof(filterWindow), "Gaussian filter window size must be between 3 to 31");
+            if (filterWindow % 2 == 0) throw new ArgumentOutOfRangeException(nameof(filterWindow), "Gaussian filter window size must be an odd number");
+            if (targetPeak <= 0 || targetPeak > 1) throw new ArgumentOutOfRangeException(nameof(targetPeak));
+            if (gainFactor < 1 || gainFactor > 100) throw new ArgumentOutOfRangeException(nameof(gainFactor), "Gain factor must be between 1.0 to 100.0");
+            if (targetRms < 0 || targetRms > 1) throw new ArgumentOutOfRangeException(nameof(targetRms), "Target RMS must be between 0.0 and 1.0");
+            if (compressorFactor < 0 || compressorFactor > 30) throw new ArgumentOutOfRangeException(nameof(compressorFactor), "Compressor factor must be between 0.0 and 30.0");
+
+            _arguments.Add("f", frameLength.ToString());
+            _arguments.Add("g", filterWindow.ToString());
+            _arguments.Add("p", targetPeak.ToString("0.00", CultureInfo.InvariantCulture));
+            _arguments.Add("m", gainFactor.ToString("0.0", CultureInfo.InvariantCulture));
+            _arguments.Add("r", targetRms.ToString("0.0", CultureInfo.InvariantCulture));
+            _arguments.Add("n", (channelCoupling ? 1 : 0).ToString());
+            _arguments.Add("c", (enableDcBiasCorrection ? 1 : 0).ToString());
+            _arguments.Add("b", (enableAlternativeBoundary ? 1 : 0).ToString());
+            _arguments.Add("s", compressorFactor.ToString("0.0", CultureInfo.InvariantCulture));
+        }
+
+        public string Key { get; } = "dynaudnorm";
+
+        public string Value => string.Join(":", _arguments.Select(pair => $"{pair.Key}={pair.Value}"));
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/PanArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/PanArgument.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+
+namespace FFMpegCore.Arguments
+{
+    /// <summary>
+    /// Represents scale parameter
+    /// </summary>
+    public class PanArgument : IAudioFilterArgument
+    {
+        public readonly string ChannelLayout;
+        private readonly string[] _outputDefinitions;
+
+        public PanArgument(string channelLayout, params string[] outputDefinitions)
+        {
+            if (string.IsNullOrWhiteSpace(channelLayout))
+            {
+                throw new ArgumentException("The channel layout must be set" ,nameof(channelLayout));
+            }
+
+            ChannelLayout = channelLayout;
+            
+            _outputDefinitions = outputDefinitions;
+        }
+
+        public PanArgument(int channels, params string[] outputDefinitions)
+        {
+            if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels));
+            
+            if (outputDefinitions.Length > channels)
+                throw new ArgumentException("The number of output definitions must be equal or lower than number of channels", nameof(outputDefinitions));
+            
+            ChannelLayout = $"{channels}c";
+
+            _outputDefinitions = outputDefinitions;
+        }
+
+        public string Key { get; } = "pan";
+
+        public string Value =>
+            string.Join("|", Enumerable.Empty<string>().Append(ChannelLayout).Concat(_outputDefinitions));
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/PanArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/PanArgument.cs
@@ -4,13 +4,22 @@ using System.Linq;
 namespace FFMpegCore.Arguments
 {
     /// <summary>
-    /// Represents scale parameter
+    ///     Mix channels with specific gain levels.
     /// </summary>
     public class PanArgument : IAudioFilterArgument
     {
         public readonly string ChannelLayout;
         private readonly string[] _outputDefinitions;
 
+        /// <summary>
+        ///     Mix channels with specific gain levels <see href="https://ffmpeg.org/ffmpeg-filters.html#toc-pan-1"/>
+        /// </summary>
+        /// <param name="channelLayout">
+        ///     Represent the output channel layout. Like "stereo", "mono", "2.1", "5.1"
+        /// </param>
+        /// <param name="outputDefinitions">
+        ///     Output channel specification, of the form: "out_name=[gain*]in_name[(+-)[gain*]in_name...]"
+        /// </param>
         public PanArgument(string channelLayout, params string[] outputDefinitions)
         {
             if (string.IsNullOrWhiteSpace(channelLayout))
@@ -23,6 +32,13 @@ namespace FFMpegCore.Arguments
             _outputDefinitions = outputDefinitions;
         }
 
+        /// <summary>
+        ///     Mix channels with specific gain levels <see href="https://ffmpeg.org/ffmpeg-filters.html#toc-pan-1"/>
+        /// </summary>
+        /// <param name="channels">Number of channels in output file</param>
+        /// <param name="outputDefinitions">
+        ///     Output channel specification, of the form: "out_name=[gain*]in_name[(+-)[gain*]in_name...]"
+        /// </param>
         public PanArgument(int channels, params string[] outputDefinitions)
         {
             if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels));

--- a/FFMpegCore/FFMpeg/Arguments/PipeArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/PipeArgument.cs
@@ -40,7 +40,7 @@ namespace FFMpegCore.Arguments
         {
             try
             {
-                await ProcessDataAsync(cancellationToken);           
+                await ProcessDataAsync(cancellationToken).ConfigureAwait(false);           
             }
             catch (TaskCanceledException)
             {

--- a/FFMpegCore/FFMpeg/Arguments/SubtitleHardBurnArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/SubtitleHardBurnArgument.cs
@@ -103,7 +103,7 @@ namespace FFMpegCore.Arguments
             return this;
         }
 
-        internal string TextInternal => string.Join(":", new[] { _subtitle.EncloseIfContainsSpace() }.Concat(Parameters.Select(parameter => parameter.FormatArgumentPair(enclose: true))));
+        internal string TextInternal => string.Join(":", new[] { _subtitle.ToFFmpegLibavfilterPath().EncloseInQuotes() }.Concat(Parameters.Select(parameter => parameter.FormatArgumentPair(enclose: true))));
     }
 
     public class StyleOptions

--- a/FFMpegCore/FFMpeg/Arguments/SubtitleHardBurnArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/SubtitleHardBurnArgument.cs
@@ -103,7 +103,9 @@ namespace FFMpegCore.Arguments
             return this;
         }
 
-        internal string TextInternal => string.Join(":", new[] { _subtitle.ToFFmpegLibavfilterPath().EncloseInQuotes() }.Concat(Parameters.Select(parameter => parameter.FormatArgumentPair(enclose: true))));
+        internal string TextInternal => string
+            .Join(":", new[] { StringExtensions.EncloseInQuotes(StringExtensions.ToFFmpegLibavfilterPath(_subtitle)) }
+            .Concat(Parameters.Select(parameter => parameter.FormatArgumentPair(enclose: true))));
     }
 
     public class StyleOptions

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -116,12 +116,9 @@ namespace FFMpegCore
         {
             captureTime ??= TimeSpan.FromSeconds(source.Duration.TotalSeconds / 3);
             size = PrepareSnapshotSize(source, size);
-            if (streamIndex == null)
-            {
-                streamIndex = source.PrimaryVideoStream?.Index
-                    ?? source.VideoStreams.First()?.Index
-                    ?? 0;
-            }
+            streamIndex ??= source.PrimaryVideoStream?.Index
+                            ?? source.VideoStreams.FirstOrDefault()?.Index
+                            ?? 0;
 
             return (FFMpegArguments
                 .FromFileInput(input, false, options => options

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -116,7 +116,12 @@ namespace FFMpegCore
         {
             captureTime ??= TimeSpan.FromSeconds(source.Duration.TotalSeconds / 3);
             size = PrepareSnapshotSize(source, size);
-            streamIndex = streamIndex == null ? 0 : source.VideoStreams.FirstOrDefault(videoStream => videoStream.Index == streamIndex).Index;
+            if (streamIndex == null)
+            {
+                streamIndex = source.PrimaryVideoStream?.Index
+                    ?? source.VideoStreams.First()?.Index
+                    ?? 0;
+            }
 
             return (FFMpegArguments
                 .FromFileInput(input, false, options => options

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -303,12 +303,13 @@ namespace FFMpegCore
         public static bool JoinImageSequence(string output, double frameRate = 30, params ImageInfo[] images)
         {
             var tempFolderName = Path.Combine(GlobalFFOptions.Current.TemporaryFilesFolder, Guid.NewGuid().ToString());
-            var temporaryImageFiles = images.Select((image, index) =>
+            var temporaryImageFiles = images.Select((imageInfo, index) =>
             {
-                FFMpegHelper.ConversionSizeExceptionCheck(Image.FromFile(image.FullName));
-                var destinationPath = Path.Combine(tempFolderName, $"{index.ToString().PadLeft(9, '0')}{image.Extension}");
+                using var image = Image.FromFile(imageInfo.FullName);
+                FFMpegHelper.ConversionSizeExceptionCheck(image);
+                var destinationPath = Path.Combine(tempFolderName, $"{index.ToString().PadLeft(9, '0')}{imageInfo.Extension}");
                 Directory.CreateDirectory(tempFolderName);
-                File.Copy(image.FullName, destinationPath);
+                File.Copy(imageInfo.FullName, destinationPath);
                 return destinationPath;
             }).ToArray();
 

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -50,7 +50,7 @@ namespace FFMpegCore
             if (Path.GetExtension(output) != FileExtension.Png)
                 output = Path.GetFileNameWithoutExtension(output) + FileExtension.Png;
 
-            var source = await FFProbe.AnalyseAsync(input);
+            var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
             var (arguments, outputOptions) = BuildSnapshotArguments(input, source, size, captureTime, streamIndex, inputFileIndex);
 
             return await arguments
@@ -93,7 +93,7 @@ namespace FFMpegCore
         /// <returns>Bitmap with the requested snapshot.</returns>
         public static async Task<Bitmap> SnapshotAsync(string input, Size? size = null, TimeSpan? captureTime = null, int? streamIndex = null, int inputFileIndex = 0)
         {
-            var source = await FFProbe.AnalyseAsync(input);
+            var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
             var (arguments, outputOptions) = BuildSnapshotArguments(input, source, size, captureTime, streamIndex, inputFileIndex);
             using var ms = new MemoryStream();
 

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -43,6 +43,13 @@ namespace FFMpegCore
             return WithArgument(new VideoFiltersArgument(videoFilterOptionsObj));
         }
 
+        public FFMpegArgumentOptions WithAudioFilters(Action<AudioFilterOptions> audioFilterOptions)
+        {
+            var audioFilterOptionsObj = new AudioFilterOptions();
+            audioFilterOptions(audioFilterOptionsObj);
+            return WithArgument(new AudioFiltersArgument(audioFilterOptionsObj));
+        }
+
         public FFMpegArgumentOptions WithFramerate(double framerate) => WithArgument(new FrameRateArgument(framerate));
         public FFMpegArgumentOptions WithoutMetadata() => WithArgument(new RemoveMetadataArgument());
         public FFMpegArgumentOptions WithSpeedPreset(Speed speed) => WithArgument(new SpeedPresetArgument(speed));

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -145,17 +145,18 @@ namespace FFMpegCore
             return exitCode == 0;
         }
 
-        private Instance PrepareInstance(FFOptions ffMpegOptions,
+        private Instance PrepareInstance(FFOptions ffOptions,
             out CancellationTokenSource cancellationTokenSource)
         {
             FFMpegHelper.RootExceptionCheck();
-            FFMpegHelper.VerifyFFMpegExists(ffMpegOptions);
+            FFMpegHelper.VerifyFFMpegExists(ffOptions);
             var startInfo = new ProcessStartInfo
             {
-                FileName = GlobalFFOptions.GetFFMpegBinaryPath(ffMpegOptions),
+                FileName = GlobalFFOptions.GetFFMpegBinaryPath(ffOptions),
                 Arguments = _ffMpegArguments.Text,
-                StandardOutputEncoding = ffMpegOptions.Encoding,
-                StandardErrorEncoding = ffMpegOptions.Encoding,
+                StandardOutputEncoding = ffOptions.Encoding,
+                StandardErrorEncoding = ffOptions.Encoding,
+                WorkingDirectory = ffOptions.WorkingDirectory
             };
             var instance = new Instance(startInfo);
             cancellationTokenSource = new CancellationTokenSource();

--- a/FFMpegCore/FFMpeg/Pipes/StreamPipeSink.cs
+++ b/FFMpegCore/FFMpeg/Pipes/StreamPipeSink.cs
@@ -17,7 +17,7 @@ namespace FFMpegCore.Pipes
         }
         public StreamPipeSink(Stream destination)
         {
-            Writer = (inputStream, cancellationToken) => inputStream.CopyToAsync(destination, BlockSize, cancellationToken);
+            Writer = async (inputStream, cancellationToken) => await inputStream.CopyToAsync(destination, BlockSize, cancellationToken).ConfigureAwait(false);
         }
 
         public Task ReadAsync(Stream inputStream, CancellationToken cancellationToken) 

--- a/FFMpegCore/FFMpeg/Pipes/StreamPipeSink.cs
+++ b/FFMpegCore/FFMpeg/Pipes/StreamPipeSink.cs
@@ -17,11 +17,11 @@ namespace FFMpegCore.Pipes
         }
         public StreamPipeSink(Stream destination)
         {
-            Writer = async (inputStream, cancellationToken) => await inputStream.CopyToAsync(destination, BlockSize, cancellationToken).ConfigureAwait(false);
+            Writer = (inputStream, cancellationToken) => inputStream.CopyToAsync(destination, BlockSize, cancellationToken);
         }
 
-        public Task ReadAsync(Stream inputStream, CancellationToken cancellationToken) 
-            => Writer(inputStream, cancellationToken);
+        public async Task ReadAsync(Stream inputStream, CancellationToken cancellationToken) 
+            => await Writer(inputStream, cancellationToken).ConfigureAwait(false);
 
         public string GetFormat() => Format;
     }

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -8,13 +8,18 @@
     <Description>A .NET Standard FFMpeg/FFProbe wrapper for easily integrating media analysis and conversion into your .NET applications</Description>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>- Support for PCM audio samples (thanks to Namaneo)
-- Support for subtitle streams in MediaAnalysis (thanks to alex6dj)
-- Support for subtitle hard burning (thanks to alex6dj)
-- Additional codec* properties on MediaAnalysis object (thanks to GuyWithDogs)
-- SelectStream method for mapping/specifyíng specific streams from input files (thanks to Feodoros)</PackageReleaseNotes>
+    <PackageReleaseNotes>- Support for reading Disposition metadata on streams in FFProbe output (thanks alex6dj)
+- Fix for stream index in Snapshot(Async) (thanks stasokrosh)
+- Add support for frame analysis through FFProbe,GetFrames(Async) (thanks andyjmorgan)
+- Fix for subtitle burning error, when subtitle path contains special characters (thanks alex6dj)
+- Support for Audio filters (thanks alex6dj)
+- Fix FFProbe.AnalyseAsync not throwing if non-zero exit-code (thanks samburovkv)
+- Change bit_rate from int to long to support analysis of high bit-rate files (thanks zhuker) 
+- Support for specifying working directory for ffmpeg and ffprobe processes through FFOptions
+- Ensure Image instances in JoinImageSequence are disposed
+- Added ConfigureAwait(false) to prevent hanging with certain frameworks</PackageReleaseNotes>
     <LangVersion>8</LangVersion>
-    <PackageVersion>4.5.0</PackageVersion>
+    <PackageVersion>4.6.0</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Malte Rosenbjerg, Vlad Jerca, Max Bagryantsev</Authors>
     <PackageTags>ffmpeg ffprobe convert video audio mediafile resize analyze muxing</PackageTags>

--- a/FFMpegCore/FFOptions.cs
+++ b/FFMpegCore/FFOptions.cs
@@ -7,6 +7,11 @@ namespace FFMpegCore
     public class FFOptions
     {
         /// <summary>
+        /// Working directory for the ffmpeg/ffprobe instance
+        /// </summary>
+        public string WorkingDirectory { get; set; } = string.Empty;
+        
+        /// <summary>
         /// Folder container ffmpeg and ffprobe binaries. Leave empty if ffmpeg and ffprobe are present in PATH
         /// </summary>
         public string BinaryFolder { get; set; } = string.Empty;

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -165,7 +165,8 @@ namespace FFMpegCore
             var startInfo = new ProcessStartInfo(GlobalFFOptions.GetFFProbeBinaryPath(), arguments)
             {
                 StandardOutputEncoding = ffOptions.Encoding,
-                StandardErrorEncoding = ffOptions.Encoding
+                StandardErrorEncoding = ffOptions.Encoding,
+                WorkingDirectory = ffOptions.WorkingDirectory
             };
             var instance = new Instance(startInfo) { DataBufferCapacity = outputCapacity };
             return instance;

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -63,13 +63,19 @@ namespace FFMpegCore
                 throw new FFMpegException(FFMpegExceptionType.File, $"No file found at '{filePath}'");
             
             using var instance = PrepareInstance(filePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            await instance.FinishedRunning().ConfigureAwait(false);
+            var exitCode = await instance.FinishedRunning().ConfigureAwait(false);
+            if (exitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+
             return ParseOutput(instance);
         }
         public static async Task<IMediaAnalysis> AnalyseAsync(Uri uri, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
         {
             using var instance = PrepareInstance(uri.AbsoluteUri, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            await instance.FinishedRunning().ConfigureAwait(false);
+            var exitCode = await instance.FinishedRunning().ConfigureAwait(false);
+            if (exitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+
             return ParseOutput(instance);
         }
         public static async Task<IMediaAnalysis> AnalyseAsync(Stream stream, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -12,7 +12,7 @@ namespace FFMpegCore
         public Format Format { get; set; } = null!;
     }
     
-    public class FFProbeStream : ITagsContainer
+    public class FFProbeStream : ITagsContainer, IDispositionContainer
     {
         [JsonPropertyName("index")]
         public int Index { get; set; }
@@ -71,9 +71,13 @@ namespace FFMpegCore
         [JsonPropertyName("sample_rate")]
         public string SampleRate { get; set; } = null!;
 
+        [JsonPropertyName("disposition")]
+        public Dictionary<string, int> Disposition { get; set; } = null!;
+
         [JsonPropertyName("tags")]
         public Dictionary<string, string> Tags { get; set; } = null!;
     }
+
     public class Format : ITagsContainer
     {
         [JsonPropertyName("filename")]
@@ -110,10 +114,16 @@ namespace FFMpegCore
         public Dictionary<string, string> Tags { get; set; } = null!;
     }
 
+    public interface IDispositionContainer
+    {
+        Dictionary<string, int> Disposition { get; set; }
+    }
+
     public interface ITagsContainer
     {
         Dictionary<string, string> Tags { get; set; }
     }
+
     public static class TagExtensions
     {
         private static string? TryGetTagValue(ITagsContainer tagsContainer, string key)
@@ -127,7 +137,18 @@ namespace FFMpegCore
         public static string? GetCreationTime(this ITagsContainer tagsContainer) => TryGetTagValue(tagsContainer, "creation_time ");
         public static string? GetRotate(this ITagsContainer tagsContainer) => TryGetTagValue(tagsContainer, "rotate");
         public static string? GetDuration(this ITagsContainer tagsContainer) => TryGetTagValue(tagsContainer, "duration");
-        
-        
+    }
+
+    public static class DispositionExtensions
+    {
+        private static int? TryGetDispositionValue(IDispositionContainer dispositionContainer, string key)
+        {
+            if (dispositionContainer.Disposition != null && dispositionContainer.Disposition.TryGetValue(key, out var dispositionValue))
+                return dispositionValue;
+            return null;
+        }
+
+        public static int? GetDefault(this IDispositionContainer tagsContainer) => TryGetDispositionValue(tagsContainer, "default");
+        public static int? GetForced(this IDispositionContainer tagsContainer) => TryGetDispositionValue(tagsContainer, "forced");
     }
 }

--- a/FFMpegCore/FFProbe/FrameAnalysis.cs
+++ b/FFMpegCore/FFProbe/FrameAnalysis.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace FFMpegCore
+{
+    public class Frame
+    {
+        public string media_type { get; set; }
+        public int stream_index { get; set; }
+        public int key_frame { get; set; }
+        public long pkt_pts { get; set; }
+        public string pkt_pts_time { get; set; }
+        public long pkt_dts { get; set; }
+        public string pkt_dts_time { get; set; }
+        public long best_effort_timestamp { get; set; }
+        public string best_effort_timestamp_time { get; set; }
+        public int pkt_duration { get; set; }
+        public string pkt_duration_time { get; set; }
+        public long pkt_pos { get; set; }
+        public int pkt_size { get; set; }
+        public long width { get; set; }
+        public long height { get; set; }
+        public string pix_fmt { get; set; }
+        public string pict_type { get; set; }
+        public long coded_picture_number { get; set; }
+        public long display_picture_number { get; set; }
+        public int interlaced_frame { get; set; }
+        public int top_field_first { get; set; }
+        public int repeat_pict { get; set; }
+        public string chroma_location { get; set; }
+    }
+
+    public class FFProbeFrames
+    {
+        public List<Frame> frames { get; set; }
+    }
+}

--- a/FFMpegCore/FFProbe/FrameAnalysis.cs
+++ b/FFMpegCore/FFProbe/FrameAnalysis.cs
@@ -1,39 +1,83 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace FFMpegCore
 {
-    public class Frame
+    public class FFProbeFrameAnalysis
     {
-        public string media_type { get; set; }
-        public int stream_index { get; set; }
-        public int key_frame { get; set; }
-        public long pkt_pts { get; set; }
-        public string pkt_pts_time { get; set; }
-        public long pkt_dts { get; set; }
-        public string pkt_dts_time { get; set; }
-        public long best_effort_timestamp { get; set; }
-        public string best_effort_timestamp_time { get; set; }
-        public int pkt_duration { get; set; }
-        public string pkt_duration_time { get; set; }
-        public long pkt_pos { get; set; }
-        public int pkt_size { get; set; }
-        public long width { get; set; }
-        public long height { get; set; }
-        public string pix_fmt { get; set; }
-        public string pict_type { get; set; }
-        public long coded_picture_number { get; set; }
-        public long display_picture_number { get; set; }
-        public int interlaced_frame { get; set; }
-        public int top_field_first { get; set; }
-        public int repeat_pict { get; set; }
-        public string chroma_location { get; set; }
+        [JsonPropertyName("media_type")]
+        public string MediaType { get; set; }
+        
+        [JsonPropertyName("stream_index")]
+        public int StreamIndex { get; set; }
+        
+        [JsonPropertyName("key_frame")]
+        public int KeyFrame { get; set; }
+        
+        [JsonPropertyName("pkt_pts")]
+        public long PacketPts { get; set; }
+        
+        [JsonPropertyName("pkt_pts_time")]
+        public string PacketPtsTime { get; set; }
+        
+        [JsonPropertyName("pkt_dts")]
+        public long PacketDts { get; set; }
+        
+        [JsonPropertyName("pkt_dts_time")]
+        public string PacketDtsTime { get; set; }
+        
+        [JsonPropertyName("best_effort_timestamp")]
+        public long BestEffortTimestamp { get; set; }
+        
+        [JsonPropertyName("best_effort_timestamp_time")]
+        public string BestEffortTimestampTime { get; set; }
+        
+        [JsonPropertyName("pkt_duration")]
+        public int PacketDuration { get; set; }
+        
+        [JsonPropertyName("pkt_duration_time")]
+        public string PacketDurationTime { get; set; }
+        
+        [JsonPropertyName("pkt_pos")]
+        public long PacketPos { get; set; }
+        
+        [JsonPropertyName("pkt_size")]
+        public int PacketSize { get; set; }
+        
+        [JsonPropertyName("width")]
+        public long Width { get; set; }
+        
+        [JsonPropertyName("height")]
+        public long Height { get; set; }
+        
+        [JsonPropertyName("pix_fmt")]
+        public string PixelFormat { get; set; }
+        
+        [JsonPropertyName("pict_type")]
+        public string PictureType { get; set; }
+        
+        [JsonPropertyName("coded_picture_number")]
+        public long CodedPictureNumber { get; set; }
+        
+        [JsonPropertyName("display_picture_number")]
+        public long DisplayPictureNumber { get; set; }
+        
+        [JsonPropertyName("interlaced_frame")]
+        public int InterlacedFrame { get; set; }
+        
+        [JsonPropertyName("top_field_first")]
+        public int TopFieldFirst { get; set; }
+        
+        [JsonPropertyName("repeat_pict")]
+        public int RepeatPicture { get; set; }
+        
+        [JsonPropertyName("chroma_location")]
+        public string ChromaLocation { get; set; }
     }
 
     public class FFProbeFrames
     {
-        public List<Frame> frames { get; set; }
+        [JsonPropertyName("frames")]
+        public List<FFProbeFrameAnalysis> Frames { get; set; }
     }
 }

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -67,6 +67,7 @@ namespace FFMpegCore
                 PixelFormat = stream.PixelFormat,
                 Rotation = (int)float.Parse(stream.GetRotate() ?? "0"),
                 Language = stream.GetLanguage(),
+                Disposition = stream.Disposition,
                 Tags = stream.Tags,
             };
         }
@@ -87,6 +88,7 @@ namespace FFMpegCore
                 SampleRateHz = !string.IsNullOrEmpty(stream.SampleRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.SampleRate) : default,
                 Profile = stream.Profile,
                 Language = stream.GetLanguage(),
+                Disposition = stream.Disposition,
                 Tags = stream.Tags,
             };
         }
@@ -101,6 +103,7 @@ namespace FFMpegCore
                 CodecLongName = stream.CodecLongName,
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
                 Language = stream.GetLanguage(),
+                Disposition = stream.Disposition,
                 Tags = stream.Tags,
             };
         }

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -52,7 +52,7 @@ namespace FFMpegCore
             {
                 Index = stream.Index,
                 AvgFrameRate = MediaAnalysisUtils.DivideRatio(MediaAnalysisUtils.ParseRatioDouble(stream.AvgFrameRate, '/')),
-                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitRate) : default,
+                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseLongInvariant(stream.BitRate) : default,
                 BitsPerRawSample = !string.IsNullOrEmpty(stream.BitsPerRawSample) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitsPerRawSample) : default,
                 CodecName = stream.CodecName,
                 CodecLongName = stream.CodecLongName,
@@ -77,7 +77,7 @@ namespace FFMpegCore
             return new AudioStream
             {
                 Index = stream.Index,
-                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitRate) : default,
+                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseLongInvariant(stream.BitRate) : default,
                 CodecName = stream.CodecName,
                 CodecLongName = stream.CodecLongName,
                 CodecTag = stream.CodecTag,
@@ -98,7 +98,7 @@ namespace FFMpegCore
             return new SubtitleStream
             {
                 Index = stream.Index,
-                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.BitRate) : default,
+                BitRate = !string.IsNullOrEmpty(stream.BitRate) ? MediaAnalysisUtils.ParseLongInvariant(stream.BitRate) : default,
                 CodecName = stream.CodecName,
                 CodecLongName = stream.CodecLongName,
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
@@ -134,6 +134,9 @@ namespace FFMpegCore
 
         public static int ParseIntInvariant(string line) =>
             int.Parse(line, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture);
+        
+        public static long ParseLongInvariant(string line) =>
+            long.Parse(line, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture);
         
         
         public static TimeSpan ParseDuration(string duration)

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -67,7 +67,7 @@ namespace FFMpegCore
                 PixelFormat = stream.PixelFormat,
                 Rotation = (int)float.Parse(stream.GetRotate() ?? "0"),
                 Language = stream.GetLanguage(),
-                Disposition = stream.Disposition,
+                Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
                 Tags = stream.Tags,
             };
         }
@@ -88,7 +88,7 @@ namespace FFMpegCore
                 SampleRateHz = !string.IsNullOrEmpty(stream.SampleRate) ? MediaAnalysisUtils.ParseIntInvariant(stream.SampleRate) : default,
                 Profile = stream.Profile,
                 Language = stream.GetLanguage(),
-                Disposition = stream.Disposition,
+                Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
                 Tags = stream.Tags,
             };
         }
@@ -103,7 +103,7 @@ namespace FFMpegCore
                 CodecLongName = stream.CodecLongName,
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
                 Language = stream.GetLanguage(),
-                Disposition = stream.Disposition,
+                Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
                 Tags = stream.Tags,
             };
         }
@@ -171,6 +171,31 @@ namespace FFMpegCore
         public static TimeSpan ParseDuration(FFProbeStream ffProbeStream)
         {
             return ParseDuration(ffProbeStream.Duration);
+        }
+
+        public static Dictionary<string, bool>? FormatDisposition(Dictionary<string, int>? disposition)
+        {
+            if (disposition == null)
+            {
+                return null;
+            }
+
+            var result = new Dictionary<string, bool>(disposition.Count);
+
+            foreach (var pair in disposition)
+            {
+                result.Add(pair.Key, ToBool(pair.Value));
+            }
+
+            static bool ToBool(int value) => value switch
+            {
+                0 => false,
+                1 => true,
+                _ => throw new ArgumentOutOfRangeException(nameof(value),
+                    $"Not expected disposition state value: {value}")
+            };
+
+            return result;
         }
     }
 }

--- a/FFMpegCore/FFProbe/MediaStream.cs
+++ b/FFMpegCore/FFProbe/MediaStream.cs
@@ -15,8 +15,9 @@ namespace FFMpegCore
         public int BitRate { get; internal set; }
         public TimeSpan Duration { get; internal set; }
         public string? Language { get; internal set; }
+        public Dictionary<string, int>? Disposition { get; internal set; }
         public Dictionary<string, string>? Tags { get; internal set; }
-
+        
         public Codec GetCodecInfo() => FFMpeg.GetCodec(CodecName);
     }
 }

--- a/FFMpegCore/FFProbe/MediaStream.cs
+++ b/FFMpegCore/FFProbe/MediaStream.cs
@@ -12,7 +12,7 @@ namespace FFMpegCore
         public string CodecLongName { get; internal set; } = null!;
         public string CodecTagString { get; set; } = null!;
         public string CodecTag { get; set; } = null!;
-        public int BitRate { get; internal set; }
+        public long BitRate { get; internal set; }
         public TimeSpan Duration { get; internal set; }
         public string? Language { get; internal set; }
         public Dictionary<string, bool>? Disposition { get; internal set; }

--- a/FFMpegCore/FFProbe/MediaStream.cs
+++ b/FFMpegCore/FFProbe/MediaStream.cs
@@ -15,7 +15,7 @@ namespace FFMpegCore
         public int BitRate { get; internal set; }
         public TimeSpan Duration { get; internal set; }
         public string? Language { get; internal set; }
-        public Dictionary<string, int>? Disposition { get; internal set; }
+        public Dictionary<string, bool>? Disposition { get; internal set; }
         public Dictionary<string, string>? Tags { get; internal set; }
         
         public Codec GetCodecInfo() => FFMpeg.GetCodec(CodecName);

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ The root and temp directory for the ffmpeg binaries can be configured via the `f
 ```
 
 ### Supporting both 32 and 64 bit processes
-If you wish to support multiple client processor architectures, you can do so by creating a folder `x64` and `x86` in the `root` directory.
-Both folders should contain the binaries (`ffmpeg.exe` and `ffprobe.exe`) for build for the respective architectures. 
+If you wish to support multiple client processor architectures, you can do so by creating two folders, `x64` and `x86`, in the `BinaryFolder` directory.
+Both folders should contain the binaries (`ffmpeg.exe` and `ffprobe.exe`) built for the respective architectures. 
 
-By doing so, the library will attempt to use either `/root/{ARCH}/(ffmpeg|ffprobe).exe`.
+By doing so, the library will attempt to use either `/{BinaryFolder}/{ARCH}/(ffmpeg|ffprobe).exe`.
 
-If these folders are not defined, it will try to find the binaries in `/root/(ffmpeg|ffprobe.exe)`.
+If these folders are not defined, it will try to find the binaries in `/{BinaryFolder}/(ffmpeg|ffprobe.exe)`.
 
 (`.exe` is only appended on Windows)
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Older versions of ffmpeg might not support all ffmpeg arguments available throug
   <img src="https://contrib.rocks/image?repo=rosenbjerg/ffmpegcore" />
 </a>
 
-## Non-code contributors
+## Other contributors
 <a href="https://github.com/tiesont"><img src="https://avatars3.githubusercontent.com/u/420293?v=4" title="tiesont" width="80" height="80"></a>
 
 


### PR DESCRIPTION
- Support for reading Disposition metadata on streams in FFProbe output (thanks @alex6dj)
- Fix for stream index in Snapshot(Async) (thanks @stasokrosh)
- Add support for frame analysis through FFProbe,GetFrames(Async) (thanks @andyjmorgan)
- Fix for subtitle burning error, when subtitle path contains special characters (thanks @alex6dj)
- Support for Audio filters (thanks @alex6dj)
- Fix FFProbe.AnalyseAsync not throwing if non-zero exit-code (thanks @samburovkv)
- Change bit_rate from int to long to support analysis of high bit-rate files (thanks @zhuker) 
- Support for specifying working directory for ffmpeg and ffprobe processes through FFOptions
- Ensure Image instances in JoinImageSequence are disposed
- Added ConfigureAwait(false) to prevent hanging with certain frameworks