### PR TITLE
Add fluent configuration of ffoptions per run

### DIFF
--- a/FFMpegCore.Examples/Program.cs
+++ b/FFMpegCore.Examples/Program.cs
@@ -98,7 +98,7 @@ IVideoFrame GetNextFrame() => throw new NotImplementedException();
             yield return GetNextFrame(); //method of generating new frames
         }
     }
-    
+
     var videoFramesSource = new RawVideoPipeSource(CreateFrames(64)) //pass IEnumerable<IVideoFrame> or IEnumerator<IVideoFrame> to constructor of RawVideoPipeSource
     {
         FrameRate = 30 //set source frame rate
@@ -115,10 +115,20 @@ IVideoFrame GetNextFrame() => throw new NotImplementedException();
     GlobalFFOptions.Configure(new FFOptions { BinaryFolder = "./bin", TemporaryFilesFolder = "/tmp" });
     // or
     GlobalFFOptions.Configure(options => options.BinaryFolder = "./bin");
-    
+
     // or individual, per-run options
     await FFMpegArguments
         .FromFileInput(inputPath)
         .OutputToFile(outputPath)
         .ProcessAsynchronously(true, new FFOptions { BinaryFolder = "./bin", TemporaryFilesFolder = "/tmp" });
+
+    // or combined, setting global defaults and adapting per-run options
+    GlobalFFOptions.Configure(new FFOptions { BinaryFolder = "./bin", TemporaryFilesFolder = "./globalTmp", WorkingDirectory = "./" });
+
+    await FFMpegArguments
+        .FromFileInput(inputPath)
+        .OutputToFile(outputPath)
+        .Configure(options => options.WorkingDirectory = "./CurrentRunWorkingDir")
+        .Configure(options => options.TemporaryFilesFolder = "./CurrentRunTmpFolder")
+        .ProcessAsynchronously();
 }

--- a/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
+++ b/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+
+namespace FFMpegCore.Test
+{
+    [TestClass]
+    public class FFMpegArgumentProcessorTest
+    {
+
+        private static FFMpegArgumentProcessor CreateArgumentProcessor() => FFMpegArguments
+                        .FromFileInput("")
+                        .OutputToFile("");
+
+
+        [TestMethod]
+        public void Processor_GlobalOptions_GetUsed()
+        {
+
+            var globalWorkingDir = "Whatever";
+            GlobalFFOptions.Configure(new FFOptions { WorkingDirectory = globalWorkingDir });
+
+            var processor = CreateArgumentProcessor();
+            var options2 = processor.GetConfiguredOptions(null);
+            options2.WorkingDirectory.Should().Be(globalWorkingDir);
+        }
+
+        [TestMethod]
+        public void Processor_SessionOptions_GetUsed()
+        {
+
+            var sessionWorkingDir = "./CurrentRunWorkingDir";
+
+            var processor = CreateArgumentProcessor();
+            processor.Configure(options => options.WorkingDirectory = sessionWorkingDir);
+            var options = processor.GetConfiguredOptions(null);
+
+            options.WorkingDirectory.Should().Be(sessionWorkingDir);
+        }
+
+
+        [TestMethod]
+        public void Processor_Options_CanBeOverridden_And_Configured()
+        {
+            var globalConfig = "Whatever";
+            GlobalFFOptions.Configure(new FFOptions { WorkingDirectory = globalConfig, TemporaryFilesFolder = globalConfig, BinaryFolder = globalConfig });
+
+
+            var processor = CreateArgumentProcessor();
+
+            var sessionTempDir = "./CurrentRunWorkingDir";
+            processor.Configure(options => options.TemporaryFilesFolder = sessionTempDir);
+
+            var overrideOptions = new FFOptions() { WorkingDirectory = "override" };
+            var options = processor.GetConfiguredOptions(overrideOptions);
+
+            options.Should().BeEquivalentTo(overrideOptions);
+            options.TemporaryFilesFolder.Should().BeEquivalentTo(sessionTempDir);
+            options.BinaryFolder.Should().NotBeEquivalentTo(globalConfig);
+        }
+
+
+        [TestMethod]
+        public void Options_Global_And_Session_Options_Can_Differ()
+        {
+            FFMpegArgumentProcessor CreateArgumentProcessor() => FFMpegArguments
+                .FromFileInput("")
+                .OutputToFile("");
+
+            var globalWorkingDir = "Whatever";
+            GlobalFFOptions.Configure(new FFOptions { WorkingDirectory = globalWorkingDir });
+
+            var processor1 = CreateArgumentProcessor();
+            var sessionWorkingDir = "./CurrentRunWorkingDir";
+            processor1.Configure(options => options.WorkingDirectory = sessionWorkingDir);
+            var options1 = processor1.GetConfiguredOptions(null);
+            options1.WorkingDirectory.Should().Be(sessionWorkingDir);
+
+
+            var processor2 = CreateArgumentProcessor();
+            var options2 = processor2.GetConfiguredOptions(null);
+            options2.WorkingDirectory.Should().Be(globalWorkingDir);
+        }
+    }
+}

--- a/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
+++ b/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
@@ -1,11 +1,19 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
+using System.Reflection;
 
 namespace FFMpegCore.Test
 {
     [TestClass]
     public class FFMpegArgumentProcessorTest
     {
+        [TestCleanup]
+        public void TestInitialize()
+
+        {
+            // After testing reset global configuration to null, to be not wrong for other test relying on configuration
+            typeof(GlobalFFOptions).GetField("_current", BindingFlags.NonPublic | BindingFlags.Static).SetValue(GlobalFFOptions.Current, null);
+        }
 
         private static FFMpegArgumentProcessor CreateArgumentProcessor() => FFMpegArguments
                         .FromFileInput("")
@@ -15,7 +23,6 @@ namespace FFMpegCore.Test
         [TestMethod]
         public void Processor_GlobalOptions_GetUsed()
         {
-
             var globalWorkingDir = "Whatever";
             GlobalFFOptions.Configure(new FFOptions { WorkingDirectory = globalWorkingDir });
 
@@ -27,7 +34,6 @@ namespace FFMpegCore.Test
         [TestMethod]
         public void Processor_SessionOptions_GetUsed()
         {
-
             var sessionWorkingDir = "./CurrentRunWorkingDir";
 
             var processor = CreateArgumentProcessor();

--- a/FFMpegCore.Test/FFMpegCore.Test.csproj
+++ b/FFMpegCore.Test/FFMpegCore.Test.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -172,7 +172,7 @@ namespace FFMpegCore
             return exitCode == 0;
         }
 
-        private FFOptions GetConfiguredOptions(FFOptions? ffOptions)
+        internal FFOptions GetConfiguredOptions(FFOptions? ffOptions)
         {
             var options = ffOptions ?? GlobalFFOptions.Current.Clone();
 
@@ -206,7 +206,7 @@ namespace FFMpegCore
             return instance;
         }
 
-        
+
         private static bool HandleException(bool throwOnError, Exception e, IReadOnlyList<string> errorData)
         {
             if (!throwOnError)

--- a/FFMpegCore/FFOptions.cs
+++ b/FFMpegCore/FFOptions.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
 namespace FFMpegCore
 {
-    public class FFOptions
+    public class FFOptions : ICloneable
     {
         /// <summary>
         /// Working directory for the ffmpeg/ffprobe instance
@@ -27,16 +28,24 @@ namespace FFMpegCore
         public Encoding Encoding { get; set; } = Encoding.Default;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public Dictionary<string, string> ExtensionOverrides { get; set; } = new Dictionary<string, string>
         {
             { "mpegts", ".ts" },
         };
-        
+
         /// <summary>
         /// Whether to cache calls to get ffmpeg codec, pixel- and container-formats
         /// </summary>
         public bool UseCache { get; set; } = true;
+
+        /// <inheritdoc/>
+        object ICloneable.Clone() => Clone();
+
+        /// <summary>
+        /// Creates a new object that is a copy of the current instance.
+        /// </summary>
+        public FFOptions Clone() => (FFOptions)MemberwiseClone();
     }
 }

--- a/README.md
+++ b/README.md
@@ -182,7 +182,17 @@ await FFMpegArguments
     .FromFileInput(inputPath)
     .OutputToFile(outputPath)
     .ProcessAsynchronously(true, new FFOptions { BinaryFolder = "./bin", TemporaryFilesFolder = "/tmp" });
-```
+
+// or combined, setting global defaults and adapting per-run options
+GlobalFFOptions.Configure(new FFOptions { BinaryFolder = "./bin", TemporaryFilesFolder = "./globalTmp", WorkingDirectory = "./" });
+
+await FFMpegArguments
+    .FromFileInput(inputPath)
+    .OutputToFile(outputPath)
+    .Configure(options => options.WorkingDirectory = "./CurrentRunWorkingDir")
+    .Configure(options => options.TemporaryFilesFolder = "./CurrentRunTmpFolder")
+    .ProcessAsynchronously();
+    ```
 
 ### Option 2
 


### PR DESCRIPTION
Thanks for closing #272 so quick,! I would like to ask for an additional configuration extension here:

Add Configure on FFMpegArgumentProcessor to fuently configure ffoptions per run.

Currently the GlobalFFOptions allows an action delegate with the configure option
```csharp
GlobalFFOptions.Configure(options => options.BinaryFolder = "./bin");
``` 

What I am missing, is the same for the per run option. I can pass a new ffoption to override all existing, but i cannot extend reconfigure the existing options per run.
This PR enables the following:
1. setting default global options
2. updating the settings on run base

```csharp
    GlobalFFOptions.Configure(options => options.BinaryFolder = "GlobalBinaryFolder...");
    GlobalFFOptions.Configure(options => options.WorkingDirectory = "GlobalWorkingDirectory");

    FFMpegArguments
        .FromFileInput(inputPath)
        .OutputToFile(outputPath, false, options => options.WithFastStart())
        .Configure(options => options.WorkingDirectory = "CurrentRun WorkingDirectory")
        .Configure(options => options.TemporaryFilesFolder = "CurrentRun TempFolder")
        .ProcessSynchronously();
```

if ok, i would extend the documentation as well