### PR TITLE
parse ffprobes -show_packets output

### DIFF
--- a/FFMpegCore/FFProbe/PacketAnalysis.cs
+++ b/FFMpegCore/FFProbe/PacketAnalysis.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace FFMpegCore
+{
+    public class FFProbePacketAnalysis
+    {
+        [JsonPropertyName("codec_type")]
+        public string CodecType { get; set; }
+
+        [JsonPropertyName("stream_index")]
+        public int StreamIndex { get; set; }
+
+        [JsonPropertyName("pts")]
+        public long Pts { get; set; }
+        
+        [JsonPropertyName("pts_time")]
+        public string PtsTime { get; set; }
+
+        [JsonPropertyName("dts")]
+        public long Dts { get; set; }
+        
+        [JsonPropertyName("dts_time")]
+        public string DtsTime { get; set; }
+
+        [JsonPropertyName("duration")]
+        public int Duration { get; set; }
+        
+        [JsonPropertyName("duration_time")]
+        public string DurationTime { get; set; }
+
+        [JsonPropertyName("size")]
+        public int Size { get; set; }
+
+        [JsonPropertyName("pos")]
+        public long Pos { get; set; }
+
+        [JsonPropertyName("flags")]
+        public string Flags { get; set; }
+    }
+
+    public class FFProbePackets
+    {
+        [JsonPropertyName("packets")]
+        public List<FFProbePacketAnalysis> Packets { get; set; }
+    }
+}


### PR DESCRIPTION
I noticed there was no parser for `-show_packets` 
It is often much faster than `-show_frames`

Example json
```json
{
    "packets": [
        {
            "codec_type": "audio",
            "stream_index": 1,
            "pts": -46360,
            "pts_time": "-0.965833",
            "dts": -46360,
            "dts_time": "-0.965833",
            "duration": 1024,
            "duration_time": "0.021333",
            "size": "842",
            "pos": "48",
            "flags": "KD",
            "side_data_list": [
                {
                    "side_data_type": "Skip Samples",
                    "skip_samples": 46360,
                    "discard_padding": 0,
                    "skip_reason": 0,
                    "discard_reason": 0
                }
            ]
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": -29029,
            "pts_time": "-0.967633",
            "dts": -29029,
            "dts_time": "-0.967633",
            "duration": 1001,
            "duration_time": "0.033367",
            "size": "149893",
            "pos": "890",
            "flags": "KD"
        },
        
```