### PR TITLE
Catch missing FFprobe.exe correctly

### DIFF
--- a/FFMpegCore/Helpers/FFProbeHelper.cs
+++ b/FFMpegCore/Helpers/FFProbeHelper.cs
@@ -27,7 +27,12 @@ namespace FFMpegCore.Helpers
         public static void VerifyFFProbeExists(FFOptions ffMpegOptions)
         {
             if (_ffprobeVerified) return;
-            var (exitCode, _) = Instance.Finish(GlobalFFOptions.GetFFProbeBinaryPath(ffMpegOptions), "-version");
+            
+            var probepath = GlobalFFOptions.GetFFProbeBinaryPath(ffMpegOptions);
+            if (!System.IO.File.Exists(probepath))
+                throw new FFProbeException("ffprobe was not found on your system");
+
+            var (exitCode, _) = Instance.Finish(probepath, "-version");
             _ffprobeVerified = exitCode == 0;
             if (!_ffprobeVerified) 
                 throw new FFProbeException("ffprobe was not found on your system");

--- a/FFMpegCore/Helpers/FFProbeHelper.cs
+++ b/FFMpegCore/Helpers/FFProbeHelper.cs
@@ -24,18 +24,19 @@ namespace FFMpegCore.Helpers
                 throw new FFOptionsException("FFProbe root is not configured in app config. Missing key 'BinaryFolder'.");
         }
         
-        public static void VerifyFFProbeExists(FFOptions ffMpegOptions)
-        {
-            if (_ffprobeVerified) return;
-            
-            var probepath = GlobalFFOptions.GetFFProbeBinaryPath(ffMpegOptions);
-            if (!System.IO.File.Exists(probepath))
-                throw new FFProbeException("ffprobe was not found on your system");
-
-            var (exitCode, _) = Instance.Finish(probepath, "-version");
-            _ffprobeVerified = exitCode == 0;
-            if (!_ffprobeVerified) 
-                throw new FFProbeException("ffprobe was not found on your system");
+        public static void VerifyFFProbeExists(FFOptions ffMpegOptions) {
+            try {
+                if (_ffprobeVerified) return;
+                var (exitCode, _) = Instance.Finish(GlobalFFOptions.GetFFProbeBinaryPath(ffMpegOptions), "-version");
+                _ffprobeVerified = exitCode == 0;
+                if (!_ffprobeVerified)
+                    throw new FFProbeException("ffprobe was not found on your system");
+            }
+            catch (System.Exception ex) {
+                if ((ex.HResult == -2147467259 /* file not found error code? */) && !System.IO.File.Exists(GlobalFFOptions.GetFFProbeBinaryPath(ffMpegOptions)))
+                        throw new FFProbeException("ffprobe was not found on your system");
+                throw ex;
+            }
         }
     }
 }


### PR DESCRIPTION
I've been trying to start working with this library and it kept thrown undescriptive "file could not be found" errors and I was wondering why.

So I integrated the source of the lib in my projects too and noticed that it threw that error in the modified file.

After adding the changes I made it properly threw the error about FFprobe.exe not being present.