### PR TITLE
Added string escape for DemuxConcatArgument

### DIFF
--- a/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
+++ b/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
 using System.Reflection;
+using FFMpegCore.Arguments;
 
 namespace FFMpegCore.Test
 {
@@ -85,6 +86,13 @@ namespace FFMpegCore.Test
             var processor2 = CreateArgumentProcessor();
             var options2 = processor2.GetConfiguredOptions(null);
             options2.WorkingDirectory.Should().Be(globalWorkingDir);
+        }
+
+        [TestMethod]
+        public void Concat_Escape()
+        {
+            var arg = new DemuxConcatArgument(new[] { @"Heaven's River\05 - Investigation.m4b" });
+            arg.Values.Should().BeEquivalentTo(new[] { @"file 'Heaven'\''s River\05 - Investigation.m4b'" });
         }
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/DemuxConcatArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/DemuxConcatArgument.cs
@@ -16,8 +16,17 @@ namespace FFMpegCore.Arguments
         public readonly IEnumerable<string> Values;
         public DemuxConcatArgument(IEnumerable<string> values)
         {
-            Values = values.Select(value => $"file '{value}'");
+            Values = values.Select(value => $"file '{Escape(value)}'");
         }
+
+        /// <summary>
+        /// Thanks slhck
+        /// https://superuser.com/a/787651/1089628
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private string Escape(string value) => value.Replace("'", @"'\''");
+        
         private readonly string _tempFileName = Path.Combine(GlobalFFOptions.Current.TemporaryFilesFolder, $"concat_{Guid.NewGuid()}.txt");
 
         public void Pre() => File.WriteAllLines(_tempFileName, Values);


### PR DESCRIPTION
Fixes issue when source files have a ``'`` in their path

Edit alt: Implemented https://ffmpeg.org/ffmpeg-utils.html#Quoting-and-escaping