### PR TITLE
V.4.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+    - .github/workflows/ci.yml
     - FFMpegCore/**
     - FFMpegCore.Test/**
   pull_request:
@@ -12,6 +13,7 @@ on:
       - master
       - release
     paths:
+    - .github/workflows/ci.yml
     - FFMpegCore/**
     - FFMpegCore.Test/**
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - master
+    paths:
+    - FFMpegCore/**
+    - FFMpegCore.Test/**
   pull_request:
     branches:
       - master
       - release
+    paths:
+    - FFMpegCore/**
+    - FFMpegCore.Test/**
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Prepare .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
     - name: Prepare FFMpeg
       uses: FedericoCarboni/setup-ffmpeg@v1
     - name: Test with dotnet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Prepare .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
     - name: Build solution
       run: dotnet build --output build -c Release
     - name: Publish NuGet package

--- a/FFMpegCore.Examples/FFMpegCore.Examples.csproj
+++ b/FFMpegCore.Examples/FFMpegCore.Examples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -334,7 +334,7 @@ namespace FFMpegCore.Test
                         .HardBurnSubtitle(SubtitleHardBurnOptions
                             .Create(subtitlePath: "sample.srt")
                             .SetCharacterEncoding("UTF-8")
-                            .SetOriginalSize(1366,768)
+                            .SetOriginalSize(1366, 768)
                             .SetSubtitleIndex(0)
                             .WithStyle(StyleOptions.Create()
                                 .WithParameter("FontName", "DejaVu Serif")
@@ -479,10 +479,21 @@ namespace FFMpegCore.Test
         {
             var str = FFMpegArguments.FromFileInput("input.mp4")
                 .OutputToFile("output.mp4", false,
-                    opt => opt.WithAudioFilters(filterOptions => filterOptions.DynamicNormalizer(125, 13, 0.9215, 5.124, 0.5458,false,true,true, 0.3333333)))
+                    opt => opt.WithAudioFilters(filterOptions => filterOptions.DynamicNormalizer(125, 13, 0.9215, 5.124, 0.5458, false, true, true, 0.3333333)))
                 .Arguments;
 
             Assert.AreEqual("-i \"input.mp4\" -af \"dynaudnorm=f=125:g=13:p=0.92:m=5.1:r=0.5:n=0:c=1:b=1:s=0.3\" \"output.mp4\"", str);
+        }
+
+        [TestMethod]
+        public void Builder_BuildString_Audible_AAXC_Decryption()
+        {
+            var str = FFMpegArguments.FromFileInput("input.aaxc", false, x => x.WithAudibleEncryptionKeys("123", "456"))
+                .MapMetaData()
+                .OutputToFile("output.m4b", true, x => x.WithTagVersion(3).DisableChannel(Channel.Video).CopyChannel(Channel.Audio))
+                .Arguments;
+
+            Assert.AreEqual("-audible_key 123 -audible_iv 456 -i \"input.aaxc\" -map_metadata 0 -id3v2_version 3 -vn -c:a copy \"output.m4b\" -y", str);
         }
     }
 }

--- a/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
+++ b/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
@@ -94,5 +94,12 @@ namespace FFMpegCore.Test
             var arg = new DemuxConcatArgument(new[] { @"Heaven's River\05 - Investigation.m4b" });
             arg.Values.Should().BeEquivalentTo(new[] { @"file 'Heaven'\''s River\05 - Investigation.m4b'" });
         }
+
+        [TestMethod]
+        public void Audible_Aaxc_Test()
+        {
+            var arg = new AudibleEncryptionKeyArgument("123", "456");
+            arg.Text.Should().Be($"-audible_key 123 -audible_iv 456");
+        }
     }
 }

--- a/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
+++ b/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
@@ -101,5 +101,13 @@ namespace FFMpegCore.Test
             var arg = new AudibleEncryptionKeyArgument("123", "456");
             arg.Text.Should().Be($"-audible_key 123 -audible_iv 456");
         }
+
+
+        [TestMethod]
+        public void Audible_Aax_Test()
+        {
+            var arg = new AudibleEncryptionKeyArgument("62689101");
+            arg.Text.Should().Be($"-activation_bytes 62689101");
+        }
     }
 }

--- a/FFMpegCore.Test/FFMpegCore.Test.csproj
+++ b/FFMpegCore.Test/FFMpegCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -12,13 +12,6 @@ namespace FFMpegCore.Test
     public class FFProbeTests
     {
         [TestMethod]
-        public void Probe_TooLongOutput()
-        {
-            Assert.ThrowsException<System.Text.Json.JsonException>(() => FFProbe.Analyse(TestResources.Mp4Video, 5));
-        }
-        
-
-        [TestMethod]
         public async Task Audio_FromStream_Duration()
         {
             var fileAnalysis = await FFProbe.AnalyseAsync(TestResources.WebmVideo);

--- a/FFMpegCore.Test/MetaDataBuilderTests.cs
+++ b/FFMpegCore.Test/MetaDataBuilderTests.cs
@@ -4,8 +4,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace FFMpegCore.Test
@@ -49,6 +51,30 @@ namespace FFMpegCore.Test
             Assert.IsTrue(serialized.Contains("genre=Synthwave; Classics", StringComparison.OrdinalIgnoreCase));
             Assert.IsTrue(serialized.Contains("title=Chapter 01", StringComparison.OrdinalIgnoreCase));
             Assert.IsTrue(serialized.Contains("album_artist=Pachelbel", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [TestMethod]
+        public void TestMapMetadata()
+        {
+            //-i "whaterver0" // index: 0
+            //-f concat -safe 0
+            //-i "\AppData\Local\Temp\concat_b511f2bf-c4af-4f71-b9bd-24d706bf4861.txt"   // index: 1
+            //-i "\AppData\Local\Temp\metadata_210d3259-3d5c-43c8-9786-54b5c414fa70.txt" // index: 2
+            //-map_metadata 2
+
+            var text0 = FFMpegArguments.FromFileInput("whaterver0")
+                .AddMetaData("WhatEver3")
+                .Text;
+
+            var text1 = FFMpegArguments.FromFileInput("whaterver0")
+                .AddDemuxConcatInput(new[] { "whaterver", "whaterver1" })
+                .AddMetaData("WhatEver3")
+                .Text;
+
+
+
+            Assert.IsTrue(Regex.IsMatch(text0, "metadata_[0-9a-f-]+\\.txt\" -map_metadata 1"), "map_metadata index is calculated incorrectly.");
+            Assert.IsTrue(Regex.IsMatch(text1, "metadata_[0-9a-f-]+\\.txt\" -map_metadata 2"), "map_metadata index is calculated incorrectly.");
         }
     }
 }

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -468,7 +468,7 @@ namespace FFMpegCore.Test
                     }
                 });
 
-            var outputFile = new TemporaryFile("out.mp4");
+            using var outputFile = new TemporaryFile("out.mp4");
             var success = FFMpeg.JoinImageSequence(outputFile, images: imageSet.ToArray());
             Assert.IsTrue(success);
             var result = FFProbe.Analyse(outputFile);

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -544,7 +544,7 @@ namespace FFMpegCore.Test
                     .WithVerbosityLevel(VerbosityLevel.Info))
                 .OutputToFile(outputFile, false, opt => opt
                     .WithDuration(TimeSpan.FromSeconds(2)))
-                .NotifyOnOutput((_, _) => dataReceived = true)
+                .NotifyOnError(_ => dataReceived = true)
                 .ProcessSynchronously();
 
             Assert.IsTrue(dataReceived);

--- a/FFMpegCore/Extend/StringExtensions.cs
+++ b/FFMpegCore/Extend/StringExtensions.cs
@@ -93,12 +93,9 @@ namespace FFMpegCore.Extend
             bool aggressiveSearch = false)
         {
             // if s or substring is null or empty, substring cannot be found in s
-            if (string.IsNullOrEmpty(s) || string.IsNullOrEmpty(substring))
-                return 0;
-
             // if the length of substring is greater than the length of s,
             // substring cannot be found in s
-            if (substring.Length > s.Length)
+            if (string.IsNullOrEmpty(s) || string.IsNullOrEmpty(substring) || substring.Length > s.Length)
                 return 0;
 
             int count = 0, n = 0;

--- a/FFMpegCore/Extend/StringExtensions.cs
+++ b/FFMpegCore/Extend/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace FFMpegCore.Extend
@@ -65,6 +66,52 @@ namespace FFMpegCore.Extend
             }
 
             return parsedString.ToString();
+        }
+
+        /// <summary>
+        /// Counts the number of occurrences of the specified substring within
+        /// the current string.
+        /// </summary>
+        /// <param name="s">The current string.</param>
+        /// <param name="substring">The substring we are searching for.</param>
+        /// <param name="aggressiveSearch">Indicates whether or not the algorithm 
+        /// should be aggressive in its search behavior (see Remarks). Default 
+        /// behavior is non-aggressive.</param>
+        /// <remarks>This algorithm has two search modes - aggressive and 
+        /// non-aggressive. When in aggressive search mode (aggressiveSearch = 
+        /// true), the algorithm will try to match at every possible starting 
+        /// character index within the string. When false, all subsequent 
+        /// character indexes within a substring match will not be evaluated. 
+        /// For example, if the string was 'abbbc' and we were searching for 
+        /// the substring 'bb', then aggressive search would find 2 matches 
+        /// with starting indexes of 1 and 2. Non aggressive search would find 
+        /// just 1 match with starting index at 1. After the match was made, 
+        /// the non aggressive search would attempt to make it's next match 
+        /// starting at index 3 instead of 2.</remarks>
+        /// <returns>The count of occurrences of the substring within the string.</returns>
+        public static int CountOccurrences(this string s, string substring,
+            bool aggressiveSearch = false)
+        {
+            // if s or substring is null or empty, substring cannot be found in s
+            if (string.IsNullOrEmpty(s) || string.IsNullOrEmpty(substring))
+                return 0;
+
+            // if the length of substring is greater than the length of s,
+            // substring cannot be found in s
+            if (substring.Length > s.Length)
+                return 0;
+
+            int count = 0, n = 0;
+            while ((n = s.IndexOf(substring, n, StringComparison.InvariantCulture)) != -1)
+            {
+                if (aggressiveSearch)
+                    n++;
+                else
+                    n += substring.Length;
+                count++;
+            }
+
+            return count;
         }
     }
 }

--- a/FFMpegCore/Extend/StringExtensions.cs
+++ b/FFMpegCore/Extend/StringExtensions.cs
@@ -67,48 +67,5 @@ namespace FFMpegCore.Extend
 
             return parsedString.ToString();
         }
-
-        /// <summary>
-        /// Counts the number of occurrences of the specified substring within
-        /// the current string.
-        /// </summary>
-        /// <param name="s">The current string.</param>
-        /// <param name="substring">The substring we are searching for.</param>
-        /// <param name="aggressiveSearch">Indicates whether or not the algorithm 
-        /// should be aggressive in its search behavior (see Remarks). Default 
-        /// behavior is non-aggressive.</param>
-        /// <remarks>This algorithm has two search modes - aggressive and 
-        /// non-aggressive. When in aggressive search mode (aggressiveSearch = 
-        /// true), the algorithm will try to match at every possible starting 
-        /// character index within the string. When false, all subsequent 
-        /// character indexes within a substring match will not be evaluated. 
-        /// For example, if the string was 'abbbc' and we were searching for 
-        /// the substring 'bb', then aggressive search would find 2 matches 
-        /// with starting indexes of 1 and 2. Non aggressive search would find 
-        /// just 1 match with starting index at 1. After the match was made, 
-        /// the non aggressive search would attempt to make it's next match 
-        /// starting at index 3 instead of 2.</remarks>
-        /// <returns>The count of occurrences of the substring within the string.</returns>
-        public static int CountOccurrences(this string s, string substring,
-            bool aggressiveSearch = false)
-        {
-            // if s or substring is null or empty, substring cannot be found in s
-            // if the length of substring is greater than the length of s,
-            // substring cannot be found in s
-            if (string.IsNullOrEmpty(s) || string.IsNullOrEmpty(substring) || substring.Length > s.Length)
-                return 0;
-
-            int count = 0, n = 0;
-            while ((n = s.IndexOf(substring, n, StringComparison.InvariantCulture)) != -1)
-            {
-                if (aggressiveSearch)
-                    n++;
-                else
-                    n += substring.Length;
-                count++;
-            }
-
-            return count;
-        }
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/AudibleEncryptionKeyArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/AudibleEncryptionKeyArgument.cs
@@ -1,0 +1,16 @@
+﻿namespace FFMpegCore.Arguments
+{
+    public class AudibleEncryptionKeyArgument : IArgument
+    {
+        private readonly string _key;
+        private readonly string _iv;
+
+        public AudibleEncryptionKeyArgument(string key, string iv)
+        {
+            _key = key;
+            _iv = iv;
+        }
+
+        public string Text => $"-audible_key {_key} -audible_iv {_iv}";
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/AudibleEncryptionKeyArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/AudibleEncryptionKeyArgument.cs
@@ -2,15 +2,27 @@
 {
     public class AudibleEncryptionKeyArgument : IArgument
     {
+        private readonly bool _aaxcMode;
+        
         private readonly string _key;
         private readonly string _iv;
 
+        private readonly string _activationBytes;
+
+
+        public AudibleEncryptionKeyArgument(string activationBytes)
+        {
+            _activationBytes = activationBytes;
+        }
+
         public AudibleEncryptionKeyArgument(string key, string iv)
         {
+            _aaxcMode = true;
+
             _key = key;
             _iv = iv;
         }
 
-        public string Text => $"-audible_key {_key} -audible_iv {_iv}";
+        public string Text => _aaxcMode ? $"-audible_key {_key} -audible_iv {_iv}" : $"-activation_bytes {_activationBytes}";
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/ID3V2VersionArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/ID3V2VersionArgument.cs
@@ -1,0 +1,14 @@
+﻿namespace FFMpegCore.Arguments
+{
+    public class ID3V2VersionArgument : IArgument
+    {
+        private readonly int _version;
+
+        public ID3V2VersionArgument(int version)
+        {
+            _version = version;
+        }
+
+        public string Text => $"-id3v2_version {_version}";
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/IDynamicArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/IDynamicArgument.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Text;
 
 namespace FFMpegCore.Arguments
 {
@@ -9,6 +10,7 @@ namespace FFMpegCore.Arguments
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        public string GetText(StringBuilder context);
+        //public string GetText(StringBuilder context);
+        public string GetText(IEnumerable<IArgument> context);
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/IDynamicArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/IDynamicArgument.cs
@@ -1,0 +1,14 @@
+﻿using System.Text;
+
+namespace FFMpegCore.Arguments
+{
+    public interface IDynamicArgument
+    {
+        /// <summary>
+        /// Same as <see cref="IArgument.Text"/>, but this receives the arguments generated before as parameter
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public string GetText(StringBuilder context);
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/InputPipeArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/InputPipeArgument.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Pipes;
+﻿using System;
+using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
 using FFMpegCore.Pipes;
@@ -23,7 +24,7 @@ namespace FFMpegCore.Arguments
         {
             await Pipe.WaitForConnectionAsync(token).ConfigureAwait(false);
             if (!Pipe.IsConnected)
-                throw new TaskCanceledException();
+                throw new OperationCanceledException();
             await Writer.WriteAsync(Pipe, token).ConfigureAwait(false);
         }
     }

--- a/FFMpegCore/FFMpeg/Arguments/MapMetadataArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/MapMetadataArgument.cs
@@ -1,0 +1,44 @@
+﻿using FFMpegCore.Extend;
+
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FFMpegCore.Arguments
+{
+    public class MapMetadataArgument : IInputArgument, IDynamicArgument
+    {
+        private readonly int? _inputIndex;
+
+        /// <summary>
+        /// Null means it takes the last input used befroe this argument
+        /// </summary>
+        /// <param name="inputIndex"></param>
+        public MapMetadataArgument(int? inputIndex = null)
+        {
+            _inputIndex = inputIndex;
+        }
+
+        public string Text => GetText(null);
+
+        public string GetText(StringBuilder context)
+        {
+            var index = _inputIndex ?? context?.ToString().CountOccurrences("-i") -1 ?? 0;
+            return $"-map_metadata {index}";
+        }
+
+
+        public Task During(CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Post()
+        {
+        }
+
+        public void Pre()
+        {
+        }
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/MetaDataArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/MetaDataArgument.cs
@@ -1,6 +1,7 @@
 ﻿using FFMpegCore.Extend;
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -28,9 +29,14 @@ namespace FFMpegCore.Arguments
 
         public void Post() => File.Delete(_tempFileName);
 
-        public string GetText(StringBuilder context)
+        public string GetText(IEnumerable<IArgument>? arguments)
         {
-            var index = context.ToString().CountOccurrences("-i");
+            arguments ??= Enumerable.Empty<IArgument>();
+
+            var index = arguments
+                .TakeWhile(x => x != this)
+                .OfType<IInputArgument>()
+                .Count();
 
             return $"-i \"{_tempFileName}\" -map_metadata {index}";
         }

--- a/FFMpegCore/FFMpeg/Arguments/MetaDataArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/MetaDataArgument.cs
@@ -1,11 +1,15 @@
-﻿using System;
+﻿using FFMpegCore.Extend;
+
+using System;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace FFMpegCore.Arguments
 {
-    public class MetaDataArgument : IInputArgument
+    public class MetaDataArgument : IInputArgument, IDynamicArgument
     {
         private readonly string _metaDataContent;
         private readonly string _tempFileName = Path.Combine(GlobalFFOptions.Current.TemporaryFilesFolder, $"metadata_{Guid.NewGuid()}.txt");
@@ -15,7 +19,7 @@ namespace FFMpegCore.Arguments
             _metaDataContent = metaDataContent;
         }
 
-        public string Text => $"-i \"{_tempFileName}\" -map_metadata 1";
+        public string Text => GetText(null);
 
         public Task During(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
@@ -23,5 +27,12 @@ namespace FFMpegCore.Arguments
         public void Pre() => File.WriteAllText(_tempFileName, _metaDataContent);
 
         public void Post() => File.Delete(_tempFileName);
+
+        public string GetText(StringBuilder context)
+        {
+            var index = context.ToString().CountOccurrences("-i");
+
+            return $"-i \"{_tempFileName}\" -map_metadata {index}";
+        }
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/MetaDataArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/MetaDataArgument.cs
@@ -30,7 +30,7 @@ namespace FFMpegCore.Arguments
 
         public string GetText(StringBuilder context)
         {
-            var index = context.ToString().CountOccurrences("-i");
+            var index = context?.ToString().CountOccurrences("-i") ?? 0;
 
             return $"-i \"{_tempFileName}\" -map_metadata {index}";
         }

--- a/FFMpegCore/FFMpeg/Arguments/PipeArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/PipeArgument.cs
@@ -42,14 +42,15 @@ namespace FFMpegCore.Arguments
             {
                 await ProcessDataAsync(cancellationToken).ConfigureAwait(false);           
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
                 Debug.WriteLine($"ProcessDataAsync on {GetType().Name} cancelled");
             }
             finally
             {
                 Debug.WriteLine($"Disconnecting NamedPipeServerStream on {GetType().Name}");
-                Pipe?.Disconnect();
+                if (Pipe is { IsConnected: true })
+                    Pipe.Disconnect();
             }
         }
 

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -325,6 +325,7 @@ namespace FFMpegCore
                 return FFMpegArguments
                     .FromFileInput(Path.Combine(tempFolderName, "%09d.png"), false)
                     .OutputToFile(output, true, options => options
+                        .ForcePixelFormat("yuv420p")
                         .Resize(firstImage.Width, firstImage.Height)
                         .WithFramerate(frameRate))
                     .ProcessSynchronously();

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -247,7 +247,10 @@ namespace FFMpegCore
         public static bool PosterWithAudio(string image, string audio, string output)
         {
             FFMpegHelper.ExtensionExceptionCheck(output, FileExtension.Mp4);
-            FFMpegHelper.ConversionSizeExceptionCheck(Image.FromFile(image));
+            using (var imageFile = Image.FromFile(image))
+            {
+                FFMpegHelper.ConversionSizeExceptionCheck(imageFile);
+            }
 
             return FFMpegArguments
                 .FromFileInput(image, false, options => options

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -254,9 +254,11 @@ namespace FFMpegCore
 
             return FFMpegArguments
                 .FromFileInput(image, false, options => options
-                    .Loop(1))
+                    .Loop(1)
+                    .ForceFormat("image2"))
                 .AddFileInput(audio)
                 .OutputToFile(output, true, options => options
+                    .ForcePixelFormat("yuv420p")
                     .WithVideoCodec(VideoCodec.LibX264)
                     .WithConstantRateFactor(21)
                     .WithAudioBitrate(AudioQuality.Normal)

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -68,6 +68,7 @@ namespace FFMpegCore
         public FFMpegArgumentOptions ForcePixelFormat(PixelFormat pixelFormat) => WithArgument(new ForcePixelFormat(pixelFormat));
 
         public FFMpegArgumentOptions WithAudibleEncryptionKeys(string key, string iv) => WithArgument(new AudibleEncryptionKeyArgument(key, iv));
+        public FFMpegArgumentOptions WithAudibleActivationBytes(string activationBytes) => WithArgument(new AudibleEncryptionKeyArgument(activationBytes));
         public FFMpegArgumentOptions WithTagVersion(int id3v2Version = 3) => WithArgument(new ID3V2VersionArgument(id3v2Version));
 
 

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+
 using FFMpegCore.Arguments;
 using FFMpegCore.Enums;
 
@@ -65,6 +66,10 @@ namespace FFMpegCore
         public FFMpegArgumentOptions ForceFormat(string format) => WithArgument(new ForceFormatArgument(format));
         public FFMpegArgumentOptions ForcePixelFormat(string pixelFormat) => WithArgument(new ForcePixelFormat(pixelFormat));
         public FFMpegArgumentOptions ForcePixelFormat(PixelFormat pixelFormat) => WithArgument(new ForcePixelFormat(pixelFormat));
+
+        public FFMpegArgumentOptions WithAudibleEncryptionKeys(string key, string iv) => WithArgument(new AudibleEncryptionKeyArgument(key, iv));
+        public FFMpegArgumentOptions WithTagVersion(int id3v2Version = 3) => WithArgument(new ID3V2VersionArgument(id3v2Version));
+
 
         public FFMpegArgumentOptions WithArgument(IArgument argument)
         {

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -22,25 +22,6 @@ namespace FFMpegCore
 
         private string GetText()
         {
-            //var sb = new StringBuilder();
-            //var appendSpace = false;
-
-            //foreach (var arg in _globalArguments.Arguments.Concat(Arguments))
-            //{
-            //    if (appendSpace)
-            //    {
-            //        sb.Append(' ');
-            //    }
-            //    else
-            //    {
-            //        appendSpace = true;
-            //    }
-
-            //    sb.Append(arg is IDynamicArgument dynArg ? dynArg.GetText(sb) : arg.Text);
-            //}
-
-            //return sb.ToString();
-
             var allArguments = _globalArguments.Arguments.Concat(Arguments).ToArray();
             return string.Join(" ", allArguments.Select(arg => arg is IDynamicArgument dynArg ? dynArg.GetText(allArguments) : arg.Text));
         }

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -23,13 +23,19 @@ namespace FFMpegCore
         private string GetText()
         {
             var sb = new StringBuilder();
+            var appendSpace = false;
 
             foreach (var arg in _globalArguments.Arguments.Concat(Arguments))
             {
-                if (sb.Length != 0)
+                if (appendSpace)
                 {
                     sb.Append(' ');
                 }
+                else
+                {
+                    appendSpace = true;
+                }
+
                 sb.Append(arg is IDynamicArgument dynArg ? dynArg.GetText(sb) : arg.Text);
             }
 

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -60,6 +60,13 @@ namespace FFMpegCore
         public FFMpegArguments AddMetaData(string content, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new MetaDataArgument(content), addArguments);
         public FFMpegArguments AddMetaData(IReadOnlyMetaData metaData, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new MetaDataArgument(MetaDataSerializer.Instance.Serialize(metaData)), addArguments);
 
+
+        /// <summary>
+        /// Maps the metadata of the given stream
+        /// </summary>
+        /// <param name="inputIndex">null means, the previous input will be used</param>
+        public FFMpegArguments MapMetaData(int? inputIndex = null, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new MapMetadataArgument(inputIndex), addArguments);
+
         private FFMpegArguments WithInput(IInputArgument inputArgument, Action<FFMpegArgumentOptions>? addArguments)
         {
             var arguments = new FFMpegArgumentOptions();

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -22,24 +22,27 @@ namespace FFMpegCore
 
         private string GetText()
         {
-            var sb = new StringBuilder();
-            var appendSpace = false;
+            //var sb = new StringBuilder();
+            //var appendSpace = false;
 
-            foreach (var arg in _globalArguments.Arguments.Concat(Arguments))
-            {
-                if (appendSpace)
-                {
-                    sb.Append(' ');
-                }
-                else
-                {
-                    appendSpace = true;
-                }
+            //foreach (var arg in _globalArguments.Arguments.Concat(Arguments))
+            //{
+            //    if (appendSpace)
+            //    {
+            //        sb.Append(' ');
+            //    }
+            //    else
+            //    {
+            //        appendSpace = true;
+            //    }
 
-                sb.Append(arg is IDynamicArgument dynArg ? dynArg.GetText(sb) : arg.Text);
-            }
+            //    sb.Append(arg is IDynamicArgument dynArg ? dynArg.GetText(sb) : arg.Text);
+            //}
 
-            return sb.ToString();
+            //return sb.ToString();
+
+            var allArguments = _globalArguments.Arguments.Concat(Arguments).ToArray();
+            return string.Join(" ", allArguments.Select(arg => arg is IDynamicArgument dynArg ? dynArg.GetText(allArguments) : arg.Text));
         }
 
         public static FFMpegArguments FromConcatInput(IEnumerable<string> filePaths, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new ConcatArgument(filePaths), addArguments);

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Instances" Version="1.6.1" />
+    <PackageReference Include="Instances" Version="2.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageReference Include="System.Text.Json" Version="5.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
 
 </Project>

--- a/FFMpegCore/FFProbe/AudioStream.cs
+++ b/FFMpegCore/FFProbe/AudioStream.cs
@@ -2,9 +2,9 @@
 {
     public class AudioStream : MediaStream
     {
-        public int Channels { get; internal set; }
-        public string ChannelLayout { get; internal set; } = null!;
-        public int SampleRateHz { get; internal set; }
-        public string Profile { get; internal set; } = null!;
+        public int Channels { get; set; }
+        public string ChannelLayout { get; set; } = null!;
+        public int SampleRateHz { get; set; }
+        public string Profile { get; set; } = null!;
     }
 }

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -163,6 +163,7 @@ namespace FFMpegCore
             if (ffprobeAnalysis?.Format == null)
                 throw new FormatNullException();
             
+            ffprobeAnalysis.ErrorData = instance.ErrorData;
             return new MediaAnalysis(ffprobeAnalysis);
         }
         private static FFProbeFrames ParseFramesOutput(Instance instance)

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -13,61 +13,61 @@ namespace FFMpegCore
 {
     public static class FFProbe
     {
-        public static IMediaAnalysis Analyse(string filePath, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static IMediaAnalysis Analyse(string filePath, FFOptions? ffOptions = null)
         {
             if (!File.Exists(filePath)) 
                 throw new FFMpegException(FFMpegExceptionType.File, $"No file found at '{filePath}'");
             
-            using var instance = PrepareStreamAnalysisInstance(filePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            var exitCode = instance.BlockUntilFinished();
-            if (exitCode != 0)
-                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+            var processArguments = PrepareStreamAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current);
+            var result = processArguments.StartAndWaitForExit();
+            if (result.ExitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", null, string.Join("\n", result.ErrorData));
             
-            return ParseOutput(instance);
+            return ParseOutput(result);
         }
-        public static FFProbeFrames GetFrames(string filePath, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static FFProbeFrames GetFrames(string filePath, FFOptions? ffOptions = null)
         {
             if (!File.Exists(filePath))
                 throw new FFMpegException(FFMpegExceptionType.File, $"No file found at '{filePath}'");
 
-            using var instance = PrepareFrameAnalysisInstance(filePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            var exitCode = instance.BlockUntilFinished();
-            if (exitCode != 0)
-                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+            var instance = PrepareFrameAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current);
+            var result = instance.StartAndWaitForExit();
+            if (result.ExitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", null, string.Join("\n", result.ErrorData));
 
-            return ParseFramesOutput(instance);
+            return ParseFramesOutput(result);
         }
 
-        public static FFProbePackets GetPackets(string filePath, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static FFProbePackets GetPackets(string filePath, FFOptions? ffOptions = null)
         {
             if (!File.Exists(filePath))
                 throw new FFMpegException(FFMpegExceptionType.File, $"No file found at '{filePath}'");
 
-            using var instance = PreparePacketAnalysisInstance(filePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            var exitCode = instance.BlockUntilFinished();
-            if (exitCode != 0)
-                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+            var instance = PreparePacketAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current);
+            var result = instance.StartAndWaitForExit();
+            if (result.ExitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", null, string.Join("\n", result.ErrorData));
 
-            return ParsePacketsOutput(instance);
+            return ParsePacketsOutput(result);
         }
 
-        public static IMediaAnalysis Analyse(Uri uri, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static IMediaAnalysis Analyse(Uri uri, FFOptions? ffOptions = null)
         {
-            using var instance = PrepareStreamAnalysisInstance(uri.AbsoluteUri, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            var exitCode = instance.BlockUntilFinished();
-            if (exitCode != 0)
-                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+            var instance = PrepareStreamAnalysisInstance(uri.AbsoluteUri, ffOptions ?? GlobalFFOptions.Current);
+            var result = instance.StartAndWaitForExit();
+            if (result.ExitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", null, string.Join("\n", result.ErrorData));
 
-            return ParseOutput(instance);
+            return ParseOutput(result);
         }
-        public static IMediaAnalysis Analyse(Stream stream, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static IMediaAnalysis Analyse(Stream stream, FFOptions? ffOptions = null)
         {
             var streamPipeSource = new StreamPipeSource(stream);
             var pipeArgument = new InputPipeArgument(streamPipeSource);
-            using var instance = PrepareStreamAnalysisInstance(pipeArgument.PipePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
+            var instance = PrepareStreamAnalysisInstance(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current);
             pipeArgument.Pre();
 
-            var task = instance.FinishedRunning();
+            var task = instance.StartAndWaitForExitAsync();
             try
             {
                 pipeArgument.During().ConfigureAwait(false).GetAwaiter().GetResult();
@@ -77,62 +77,62 @@ namespace FFMpegCore
             {
                 pipeArgument.Post();
             }
-            var exitCode = task.ConfigureAwait(false).GetAwaiter().GetResult();
-            if (exitCode != 0)
-                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+            var result = task.ConfigureAwait(false).GetAwaiter().GetResult();
+            if (result.ExitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", null, string.Join("\n", result.ErrorData));
             
-            return ParseOutput(instance);
+            return ParseOutput(result);
         }
-        public static async Task<IMediaAnalysis> AnalyseAsync(string filePath, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static async Task<IMediaAnalysis> AnalyseAsync(string filePath, FFOptions? ffOptions = null)
         {
             if (!File.Exists(filePath)) 
                 throw new FFMpegException(FFMpegExceptionType.File, $"No file found at '{filePath}'");
             
-            using var instance = PrepareStreamAnalysisInstance(filePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            var exitCode = await instance.FinishedRunning().ConfigureAwait(false);
-            if (exitCode != 0)
-                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+            var instance = PrepareStreamAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current);
+            var result = await instance.StartAndWaitForExitAsync().ConfigureAwait(false);
+            if (result.ExitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", null, string.Join("\n", result.ErrorData));
 
-            return ParseOutput(instance);
+            return ParseOutput(result);
         }
 
-        public static async Task<FFProbeFrames> GetFramesAsync(string filePath, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static async Task<FFProbeFrames> GetFramesAsync(string filePath, FFOptions? ffOptions = null)
         {
             if (!File.Exists(filePath))
                 throw new FFMpegException(FFMpegExceptionType.File, $"No file found at '{filePath}'");
 
-            using var instance = PrepareFrameAnalysisInstance(filePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            await instance.FinishedRunning().ConfigureAwait(false);
-            return ParseFramesOutput(instance);
+            var instance = PrepareFrameAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current);
+            var result = await instance.StartAndWaitForExitAsync().ConfigureAwait(false);
+            return ParseFramesOutput(result);
         }
 
-        public static async Task<FFProbePackets> GetPacketsAsync(string filePath, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static async Task<FFProbePackets> GetPacketsAsync(string filePath, FFOptions? ffOptions = null)
         {
             if (!File.Exists(filePath))
                 throw new FFMpegException(FFMpegExceptionType.File, $"No file found at '{filePath}'");
 
-            using var instance = PreparePacketAnalysisInstance(filePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            await instance.FinishedRunning().ConfigureAwait(false);
-            return ParsePacketsOutput(instance);
+            var instance = PreparePacketAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current);
+            var result = await instance.StartAndWaitForExitAsync().ConfigureAwait(false);
+            return ParsePacketsOutput(result);
         }
 
-        public static async Task<IMediaAnalysis> AnalyseAsync(Uri uri, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static async Task<IMediaAnalysis> AnalyseAsync(Uri uri, FFOptions? ffOptions = null)
         {
-            using var instance = PrepareStreamAnalysisInstance(uri.AbsoluteUri, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
-            var exitCode = await instance.FinishedRunning().ConfigureAwait(false);
-            if (exitCode != 0)
-                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", null, string.Join("\n", instance.ErrorData));
+            var instance = PrepareStreamAnalysisInstance(uri.AbsoluteUri, ffOptions ?? GlobalFFOptions.Current);
+            var result = await instance.StartAndWaitForExitAsync().ConfigureAwait(false);
+            if (result.ExitCode != 0)
+                throw new FFMpegException(FFMpegExceptionType.Process, $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", null, string.Join("\n", result.ErrorData));
 
-            return ParseOutput(instance);
+            return ParseOutput(result);
         }
-        public static async Task<IMediaAnalysis> AnalyseAsync(Stream stream, int outputCapacity = int.MaxValue, FFOptions? ffOptions = null)
+        public static async Task<IMediaAnalysis> AnalyseAsync(Stream stream, FFOptions? ffOptions = null)
         {
             var streamPipeSource = new StreamPipeSource(stream);
             var pipeArgument = new InputPipeArgument(streamPipeSource);
-            using var instance = PrepareStreamAnalysisInstance(pipeArgument.PipePath, outputCapacity, ffOptions ?? GlobalFFOptions.Current);
+            var instance = PrepareStreamAnalysisInstance(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current);
             pipeArgument.Pre();
 
-            var task = instance.FinishedRunning();
+            var task = instance.StartAndWaitForExitAsync();
             try
             {
                 await pipeArgument.During().ConfigureAwait(false);
@@ -144,15 +144,15 @@ namespace FFMpegCore
             {
                 pipeArgument.Post();
             }
-            var exitCode = await task.ConfigureAwait(false);
-            if (exitCode != 0)
-                throw new FFProbeProcessException($"ffprobe exited with non-zero exit-code ({exitCode} - {string.Join("\n", instance.ErrorData)})", instance.ErrorData);
+            var result = await task.ConfigureAwait(false);
+            if (result.ExitCode != 0)
+                throw new FFProbeProcessException($"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})", result.ErrorData);
             
             pipeArgument.Post();
-            return ParseOutput(instance);
+            return ParseOutput(result);
         }
 
-        private static IMediaAnalysis ParseOutput(Instance instance)
+        private static IMediaAnalysis ParseOutput(IProcessResult instance)
         {
             var json = string.Join(string.Empty, instance.OutputData);
             var ffprobeAnalysis = JsonSerializer.Deserialize<FFProbeAnalysis>(json, new JsonSerializerOptions
@@ -165,7 +165,7 @@ namespace FFMpegCore
             
             return new MediaAnalysis(ffprobeAnalysis);
         }
-        private static FFProbeFrames ParseFramesOutput(Instance instance)
+        private static FFProbeFrames ParseFramesOutput(IProcessResult instance)
         {
             var json = string.Join(string.Empty, instance.OutputData);
             var ffprobeAnalysis = JsonSerializer.Deserialize<FFProbeFrames>(json, new JsonSerializerOptions
@@ -177,7 +177,7 @@ namespace FFMpegCore
             return ffprobeAnalysis;
         }
 
-        private static FFProbePackets ParsePacketsOutput(Instance instance)
+        private static FFProbePackets ParsePacketsOutput(IProcessResult instance)
         {
             var json = string.Join(string.Empty, instance.OutputData);
             var ffprobeAnalysis = JsonSerializer.Deserialize<FFProbePackets>(json, new JsonSerializerOptions
@@ -190,14 +190,14 @@ namespace FFMpegCore
         }
 
 
-        private static Instance PrepareStreamAnalysisInstance(string filePath, int outputCapacity, FFOptions ffOptions)
-            => PrepareInstance($"-loglevel error -print_format json -show_format -sexagesimal -show_streams \"{filePath}\"", outputCapacity, ffOptions);
-        private static Instance PrepareFrameAnalysisInstance(string filePath, int outputCapacity, FFOptions ffOptions)
-            => PrepareInstance($"-loglevel error -print_format json -show_frames -v quiet -sexagesimal \"{filePath}\"", outputCapacity, ffOptions);
-        private static Instance PreparePacketAnalysisInstance(string filePath, int outputCapacity, FFOptions ffOptions)
-            => PrepareInstance($"-loglevel error -print_format json -show_packets -v quiet -sexagesimal \"{filePath}\"", outputCapacity, ffOptions);
+        private static ProcessArguments PrepareStreamAnalysisInstance(string filePath, FFOptions ffOptions)
+            => PrepareInstance($"-loglevel error -print_format json -show_format -sexagesimal -show_streams \"{filePath}\"", ffOptions);
+        private static ProcessArguments PrepareFrameAnalysisInstance(string filePath, FFOptions ffOptions)
+            => PrepareInstance($"-loglevel error -print_format json -show_frames -v quiet -sexagesimal \"{filePath}\"", ffOptions);
+        private static ProcessArguments PreparePacketAnalysisInstance(string filePath, FFOptions ffOptions)
+            => PrepareInstance($"-loglevel error -print_format json -show_packets -v quiet -sexagesimal \"{filePath}\"", ffOptions);
         
-        private static Instance PrepareInstance(string arguments, int outputCapacity, FFOptions ffOptions)
+        private static ProcessArguments PrepareInstance(string arguments, FFOptions ffOptions)
         {
             FFProbeHelper.RootExceptionCheck();
             FFProbeHelper.VerifyFFProbeExists(ffOptions);
@@ -207,8 +207,7 @@ namespace FFMpegCore
                 StandardErrorEncoding = ffOptions.Encoding,
                 WorkingDirectory = ffOptions.WorkingDirectory
             };
-            var instance = new Instance(startInfo) { DataBufferCapacity = outputCapacity };
-            return instance;
+            return new ProcessArguments(startInfo);
         }
     }
 }

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -201,7 +201,7 @@ namespace FFMpegCore
         {
             FFProbeHelper.RootExceptionCheck();
             FFProbeHelper.VerifyFFProbeExists(ffOptions);
-            var startInfo = new ProcessStartInfo(GlobalFFOptions.GetFFProbeBinaryPath(), arguments)
+            var startInfo = new ProcessStartInfo(GlobalFFOptions.GetFFProbeBinaryPath(ffOptions), arguments)
             {
                 StandardOutputEncoding = ffOptions.Encoding,
                 StandardErrorEncoding = ffOptions.Encoding,

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -163,7 +163,7 @@ namespace FFMpegCore
                 NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString | System.Text.Json.Serialization.JsonNumberHandling.WriteAsString
             }) ;
 
-            return ffprobeAnalysis;
+            return ffprobeAnalysis!;
         }
 
         private static FFProbePackets ParsePacketsOutput(IProcessResult instance)
@@ -175,7 +175,7 @@ namespace FFMpegCore
                 NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString | System.Text.Json.Serialization.JsonNumberHandling.WriteAsString
             }) ;
 
-            return ffprobeAnalysis;
+            return ffprobeAnalysis!;
         }
 
         private static void ThrowIfInputFileDoesNotExist(string filePath)

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -10,6 +10,9 @@ namespace FFMpegCore
         
         [JsonPropertyName("format")]
         public Format Format { get; set; } = null!;
+        
+        [JsonIgnore]
+        public IReadOnlyList<string> ErrorData { get; set; }
     }
     
     public class FFProbeStream : ITagsContainer, IDispositionContainer

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -64,9 +64,6 @@ namespace FFMpegCore
 
         [JsonPropertyName("r_frame_rate")]
         public string FrameRate { get; set; } = null!;
-
-        [JsonPropertyName("avg_frame_rate")]
-        public string AverageFrameRate { get; set; } = null!;
         
         [JsonPropertyName("pix_fmt")]
         public string PixelFormat { get; set; } = null!;

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -64,6 +64,9 @@ namespace FFMpegCore
 
         [JsonPropertyName("r_frame_rate")]
         public string FrameRate { get; set; } = null!;
+
+        [JsonPropertyName("avg_frame_rate")]
+        public string AverageFrameRate { get; set; } = null!;
         
         [JsonPropertyName("pix_fmt")]
         public string PixelFormat { get; set; } = null!;

--- a/FFMpegCore/FFProbe/FrameAnalysis.cs
+++ b/FFMpegCore/FFProbe/FrameAnalysis.cs
@@ -6,7 +6,7 @@ namespace FFMpegCore
     public class FFProbeFrameAnalysis
     {
         [JsonPropertyName("media_type")]
-        public string MediaType { get; set; }
+        public string MediaType { get; set; } = null!;
         
         [JsonPropertyName("stream_index")]
         public int StreamIndex { get; set; }
@@ -18,25 +18,25 @@ namespace FFMpegCore
         public long PacketPts { get; set; }
         
         [JsonPropertyName("pkt_pts_time")]
-        public string PacketPtsTime { get; set; }
+        public string PacketPtsTime { get; set; } = null!;
         
         [JsonPropertyName("pkt_dts")]
         public long PacketDts { get; set; }
         
         [JsonPropertyName("pkt_dts_time")]
-        public string PacketDtsTime { get; set; }
+        public string PacketDtsTime { get; set; } = null!;
         
         [JsonPropertyName("best_effort_timestamp")]
         public long BestEffortTimestamp { get; set; }
         
         [JsonPropertyName("best_effort_timestamp_time")]
-        public string BestEffortTimestampTime { get; set; }
+        public string BestEffortTimestampTime { get; set; } = null!;
         
         [JsonPropertyName("pkt_duration")]
         public int PacketDuration { get; set; }
         
         [JsonPropertyName("pkt_duration_time")]
-        public string PacketDurationTime { get; set; }
+        public string PacketDurationTime { get; set; } = null!;
         
         [JsonPropertyName("pkt_pos")]
         public long PacketPos { get; set; }
@@ -51,10 +51,10 @@ namespace FFMpegCore
         public long Height { get; set; }
         
         [JsonPropertyName("pix_fmt")]
-        public string PixelFormat { get; set; }
+        public string PixelFormat { get; set; } = null!;
         
         [JsonPropertyName("pict_type")]
-        public string PictureType { get; set; }
+        public string PictureType { get; set; } = null!;
         
         [JsonPropertyName("coded_picture_number")]
         public long CodedPictureNumber { get; set; }
@@ -72,12 +72,12 @@ namespace FFMpegCore
         public int RepeatPicture { get; set; }
         
         [JsonPropertyName("chroma_location")]
-        public string ChromaLocation { get; set; }
+        public string ChromaLocation { get; set; } = null!;
     }
 
     public class FFProbeFrames
     {
         [JsonPropertyName("frames")]
-        public List<FFProbeFrameAnalysis> Frames { get; set; }
+        public List<FFProbeFrameAnalysis> Frames { get; set; } = null!;
     }
 }

--- a/FFMpegCore/FFProbe/IMediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/IMediaAnalysis.cs
@@ -13,5 +13,6 @@ namespace FFMpegCore
         List<VideoStream> VideoStreams { get; }
         List<AudioStream> AudioStreams { get; }
         List<SubtitleStream> SubtitleStreams { get; }
+        IReadOnlyList<string> ErrorData { get; }
     }
 }

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -13,6 +13,7 @@ namespace FFMpegCore
             VideoStreams = analysis.Streams.Where(stream => stream.CodecType == "video").Select(ParseVideoStream).ToList();
             AudioStreams = analysis.Streams.Where(stream => stream.CodecType == "audio").Select(ParseAudioStream).ToList();
             SubtitleStreams = analysis.Streams.Where(stream => stream.CodecType == "subtitle").Select(ParseSubtitleStream).ToList();
+            ErrorData = analysis.ErrorData ?? new List<string>().AsReadOnly();
         }
         
         private MediaFormat ParseFormat(Format analysisFormat)
@@ -45,7 +46,8 @@ namespace FFMpegCore
         public List<VideoStream> VideoStreams { get; }
         public List<AudioStream> AudioStreams { get; }
         public List<SubtitleStream> SubtitleStreams { get; }
-
+        public IReadOnlyList<string> ErrorData { get; }
+        
         private VideoStream ParseVideoStream(FFProbeStream stream)
         {
             return new VideoStream

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -114,9 +114,9 @@ namespace FFMpegCore
     {
         private static readonly Regex DurationRegex = new Regex(@"^(\d+):(\d{1,2}):(\d{1,2})\.(\d{1,3})", RegexOptions.Compiled);
 
-        internal static Dictionary<string, string> ToCaseInsensitive(this Dictionary<string, string> dictionary)
+        internal static Dictionary<string, string>? ToCaseInsensitive(this Dictionary<string, string>? dictionary)
         {
-            return dictionary.ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.OrdinalIgnoreCase);
+            return dictionary?.ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.OrdinalIgnoreCase) ?? new Dictionary<string, string>();
         }
         public static double DivideRatio((double, double) ratio) => ratio.Item1 / ratio.Item2;
 

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -61,6 +61,7 @@ namespace FFMpegCore
                 DisplayAspectRatio = MediaAnalysisUtils.ParseRatioInt(stream.DisplayAspectRatio, ':'),
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
                 FrameRate = MediaAnalysisUtils.DivideRatio(MediaAnalysisUtils.ParseRatioDouble(stream.FrameRate, '/')),
+                AverageFrameRate = MediaAnalysisUtils.DivideRatio(MediaAnalysisUtils.ParseRatioDouble(stream.AverageFrameRate, '/')),
                 Height = stream.Height ?? 0,
                 Width = stream.Width ?? 0,
                 Profile = stream.Profile,

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -25,7 +25,7 @@ namespace FFMpegCore
                 StreamCount = analysisFormat.NbStreams,
                 ProbeScore = analysisFormat.ProbeScore,
                 BitRate = long.Parse(analysisFormat.BitRate ?? "0"),
-                Tags = analysisFormat.Tags,
+                Tags = analysisFormat.Tags.ToCaseInsensitive(),
             };
         }
 
@@ -69,7 +69,7 @@ namespace FFMpegCore
                 Rotation = (int)float.Parse(stream.GetRotate() ?? "0"),
                 Language = stream.GetLanguage(),
                 Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
-                Tags = stream.Tags,
+                Tags = stream.Tags.ToCaseInsensitive(),
             };
         }
 
@@ -90,7 +90,7 @@ namespace FFMpegCore
                 Profile = stream.Profile,
                 Language = stream.GetLanguage(),
                 Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
-                Tags = stream.Tags,
+                Tags = stream.Tags.ToCaseInsensitive(),
             };
         }
 
@@ -105,15 +105,20 @@ namespace FFMpegCore
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
                 Language = stream.GetLanguage(),
                 Disposition = MediaAnalysisUtils.FormatDisposition(stream.Disposition),
-                Tags = stream.Tags,
+                Tags = stream.Tags.ToCaseInsensitive(),
             };
         }
+
     }
 
     public static class MediaAnalysisUtils
     {
         private static readonly Regex DurationRegex = new Regex(@"^(\d+):(\d{1,2}):(\d{1,2})\.(\d{1,3})", RegexOptions.Compiled);
 
+        internal static Dictionary<string, string> ToCaseInsensitive(this Dictionary<string, string> dictionary)
+        {
+            return dictionary.ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.OrdinalIgnoreCase);
+        }
         public static double DivideRatio((double, double) ratio) => ratio.Item1 / ratio.Item2;
 
         public static (int, int) ParseRatioInt(string input, char separator)
@@ -184,7 +189,7 @@ namespace FFMpegCore
                 return null;
             }
 
-            var result = new Dictionary<string, bool>(disposition.Count);
+            var result = new Dictionary<string, bool>(disposition.Count, StringComparer.Ordinal);
 
             foreach (var pair in disposition)
             {

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -61,7 +61,6 @@ namespace FFMpegCore
                 DisplayAspectRatio = MediaAnalysisUtils.ParseRatioInt(stream.DisplayAspectRatio, ':'),
                 Duration = MediaAnalysisUtils.ParseDuration(stream),
                 FrameRate = MediaAnalysisUtils.DivideRatio(MediaAnalysisUtils.ParseRatioDouble(stream.FrameRate, '/')),
-                AverageFrameRate = MediaAnalysisUtils.DivideRatio(MediaAnalysisUtils.ParseRatioDouble(stream.AverageFrameRate, '/')),
                 Height = stream.Height ?? 0,
                 Width = stream.Width ?? 0,
                 Profile = stream.Profile,

--- a/FFMpegCore/FFProbe/MediaStream.cs
+++ b/FFMpegCore/FFProbe/MediaStream.cs
@@ -5,18 +5,18 @@ using System.Collections.Generic;
 
 namespace FFMpegCore
 {
-    public class MediaStream
+    public abstract class MediaStream
     {
-        public int Index { get; internal set; }
-        public string CodecName { get; internal set; } = null!;
-        public string CodecLongName { get; internal set; } = null!;
+        public int Index { get; set; }
+        public string CodecName { get; set; } = null!;
+        public string CodecLongName { get; set; } = null!;
         public string CodecTagString { get; set; } = null!;
         public string CodecTag { get; set; } = null!;
-        public long BitRate { get; internal set; }
-        public TimeSpan Duration { get; internal set; }
-        public string? Language { get; internal set; }
-        public Dictionary<string, bool>? Disposition { get; internal set; }
-        public Dictionary<string, string>? Tags { get; internal set; }
+        public long BitRate { get; set; }
+        public TimeSpan Duration { get; set; }
+        public string? Language { get; set; }
+        public Dictionary<string, bool>? Disposition { get; set; }
+        public Dictionary<string, string>? Tags { get; set; }
         
         public Codec GetCodecInfo() => FFMpeg.GetCodec(CodecName);
     }

--- a/FFMpegCore/FFProbe/PacketAnalysis.cs
+++ b/FFMpegCore/FFProbe/PacketAnalysis.cs
@@ -6,7 +6,7 @@ namespace FFMpegCore
     public class FFProbePacketAnalysis
     {
         [JsonPropertyName("codec_type")]
-        public string CodecType { get; set; }
+        public string CodecType { get; set; } = null!;
 
         [JsonPropertyName("stream_index")]
         public int StreamIndex { get; set; }
@@ -15,19 +15,19 @@ namespace FFMpegCore
         public long Pts { get; set; }
         
         [JsonPropertyName("pts_time")]
-        public string PtsTime { get; set; }
+        public string PtsTime { get; set; } = null!;
 
         [JsonPropertyName("dts")]
         public long Dts { get; set; }
         
         [JsonPropertyName("dts_time")]
-        public string DtsTime { get; set; }
+        public string DtsTime { get; set; } = null!;
 
         [JsonPropertyName("duration")]
         public int Duration { get; set; }
         
         [JsonPropertyName("duration_time")]
-        public string DurationTime { get; set; }
+        public string DurationTime { get; set; } = null!;
 
         [JsonPropertyName("size")]
         public int Size { get; set; }
@@ -36,12 +36,12 @@ namespace FFMpegCore
         public long Pos { get; set; }
 
         [JsonPropertyName("flags")]
-        public string Flags { get; set; }
+        public string Flags { get; set; } = null!;
     }
 
     public class FFProbePackets
     {
         [JsonPropertyName("packets")]
-        public List<FFProbePacketAnalysis> Packets { get; set; }
+        public List<FFProbePacketAnalysis> Packets { get; set; } = null!;
     }
 }

--- a/FFMpegCore/FFProbe/ProcessArgumentsExtensions.cs
+++ b/FFMpegCore/FFProbe/ProcessArgumentsExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Instances;
+
+namespace FFMpegCore
+{
+    public static class ProcessArgumentsExtensions
+    {
+        public static IProcessResult StartAndWaitForExit(this ProcessArguments processArguments)
+        {
+            using var instance = processArguments.Start();
+            return instance.WaitForExit();
+        }
+        public static async Task<IProcessResult> StartAndWaitForExitAsync(this ProcessArguments processArguments, CancellationToken cancellationToken = default)
+        {
+            using var instance = processArguments.Start();
+            return await instance.WaitForExitAsync(cancellationToken);
+        }
+    }
+}

--- a/FFMpegCore/FFProbe/VideoStream.cs
+++ b/FFMpegCore/FFProbe/VideoStream.cs
@@ -4,14 +4,14 @@ namespace FFMpegCore
 {
     public class VideoStream : MediaStream
     {
-        public double AvgFrameRate { get; internal set; }
-        public int BitsPerRawSample { get; internal set; }
-        public (int Width, int Height) DisplayAspectRatio { get; internal set; }
-        public string Profile { get; internal set; } = null!;
-        public int Width { get; internal set; }
-        public int Height { get; internal set; }
-        public double FrameRate { get; internal set; }
-        public string PixelFormat { get; internal set; } = null!;
+        public double AvgFrameRate { get; set; }
+        public int BitsPerRawSample { get; set; }
+        public (int Width, int Height) DisplayAspectRatio { get; set; }
+        public string Profile { get; set; } = null!;
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public double FrameRate { get; set; }
+        public string PixelFormat { get; set; } = null!;
         public int Rotation { get; set; }
         public double AverageFrameRate { get; set; }
 

--- a/FFMpegCore/FFProbe/VideoStream.cs
+++ b/FFMpegCore/FFProbe/VideoStream.cs
@@ -13,6 +13,7 @@ namespace FFMpegCore
         public double FrameRate { get; internal set; }
         public string PixelFormat { get; internal set; } = null!;
         public int Rotation { get; set; }
+        public double AverageFrameRate { get; set; }
 
         public PixelFormat GetPixelFormatInfo() => FFMpeg.GetPixelFormat(PixelFormat);
     }

--- a/FFMpegCore/Helpers/FFMpegHelper.cs
+++ b/FFMpegCore/Helpers/FFMpegHelper.cs
@@ -38,8 +38,8 @@ namespace FFMpegCore.Helpers
         public static void VerifyFFMpegExists(FFOptions ffMpegOptions)
         {
             if (_ffmpegVerified) return;
-            var (exitCode, _) = Instance.Finish(GlobalFFOptions.GetFFMpegBinaryPath(ffMpegOptions), "-version");
-            _ffmpegVerified = exitCode == 0;
+            var result = Instance.Finish(GlobalFFOptions.GetFFMpegBinaryPath(ffMpegOptions), "-version");
+            _ffmpegVerified = result.ExitCode == 0;
             if (!_ffmpegVerified) 
                 throw new FFMpegException(FFMpegExceptionType.Operation, "ffmpeg was not found on your system");
         }

--- a/FFMpegCore/Helpers/FFProbeHelper.cs
+++ b/FFMpegCore/Helpers/FFProbeHelper.cs
@@ -27,8 +27,8 @@ namespace FFMpegCore.Helpers
         public static void VerifyFFProbeExists(FFOptions ffMpegOptions)
         {
             if (_ffprobeVerified) return;
-            var (exitCode, _) = Instance.Finish(GlobalFFOptions.GetFFProbeBinaryPath(ffMpegOptions), "-version");
-            _ffprobeVerified = exitCode == 0;
+            var result = Instance.Finish(GlobalFFOptions.GetFFProbeBinaryPath(ffMpegOptions), "-version");
+            _ffprobeVerified = result.ExitCode == 0;
             if (!_ffprobeVerified) 
                 throw new FFProbeException("ffprobe was not found on your system");
         }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![GitHub issues](https://img.shields.io/github/issues/rosenbjerg/FFMpegCore)](https://github.com/rosenbjerg/FFMpegCore/issues)
 [![GitHub stars](https://img.shields.io/github/stars/rosenbjerg/FFMpegCore)](https://github.com/rosenbjerg/FFMpegCore/stargazers)
 [![GitHub](https://img.shields.io/github/license/rosenbjerg/FFMpegCore)](https://github.com/rosenbjerg/FFMpegCore/blob/master/LICENSE)
-[![CI](https://github.com/rosenbjerg/FFMpegCore/workflows/CI/badge.svg)](https://github.com/rosenbjerg/FFMpegCore/actions?query=workflow%3ACI)
+[![CI](https://github.com/rosenbjerg/FFMpegCore/workflows/CI/badge.svg)](https://github.com/rosenbjerg/FFMpegCore/actions/workflows/ci.yml)
+[![GitHub code contributors](https://img.shields.io/github/contributors/rosenbjerg/FFMpegCore)](https://github.com/rosenbjerg/FFMpegCore/graphs/contributors)
 
 A .NET Standard FFMpeg/FFProbe wrapper for easily integrating media analysis and conversion into your .NET applications. Supports both synchronous and asynchronous calls
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A .NET Standard FFMpeg/FFProbe wrapper for easily integrating media analysis and
 # API
 
 ## FFProbe
-
 Use FFProbe to analyze media files:
 
 ```csharp
@@ -22,12 +21,12 @@ or
 var mediaInfo = FFProbe.Analyse(inputPath);
 ```
 
-
 ## FFMpeg
 Use FFMpeg to convert your media files.
 Easily build your FFMpeg arguments using the fluent argument builder:
 
 Convert input file to h264/aac scaled to 720p w/ faststart, for web playback
+
 ```csharp
 FFMpegArguments
     .FromFileInput(inputPath)
@@ -193,7 +192,7 @@ await FFMpegArguments
     .Configure(options => options.WorkingDirectory = "./CurrentRunWorkingDir")
     .Configure(options => options.TemporaryFilesFolder = "./CurrentRunTmpFolder")
     .ProcessAsynchronously();
-    ```
+```
 
 ### Option 2
 


### PR DESCRIPTION
- Fixes for `MetaDataArgument` (thanks @JKamsker)
- Support for Audible `aaxc` (thanks @JKamsker)
- Include errordata in `IMediaAnalysis` (thanks @JKamsker)
- Pass `FFOptions` properly when using ffprobe (thanks @Notheisz57)
- CancellationToken support for `AnalyseAsync`
- Case-insensitive dictionaries for `Tags` and `Disposition`
- Fix for `PosterWithAudio`
- Fix for `JoinImageSequence`
- Updates to dependendies
- A lot of bug fixes