### PR TITLE
Add Stream mapping of multiple streams and negative mapping of streams (deselect)

### DIFF
--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -114,7 +114,7 @@ namespace FFMpegCore.Test
         {
             var str = FFMpegArguments.FromFileInput("input.mp4")
                 .OutputToFile("output.mp4", false, opt => opt.CopyChannel()).Arguments;
-            Assert.AreEqual("-i \"input.mp4\" -c copy \"output.mp4\"", str);
+            Assert.AreEqual("-i \"input.mp4\" -c:a copy -c:v copy \"output.mp4\"", str);
         }
 
         [TestMethod]

--- a/FFMpegCore/FFMpeg/Arguments/CopyArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/CopyArgument.cs
@@ -16,9 +16,8 @@ namespace FFMpegCore.Arguments
 
         public string Text => Channel switch
         {
-            Channel.Audio => "-c:a copy",
-            Channel.Video => "-c:v copy",
-            _ => "-c copy"
+            Channel.Both => "-c:a copy -c:v copy",
+            _ => $"-c{Channel.StreamType()} copy"
         };
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/MapStreamArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/MapStreamArgument.cs
@@ -1,19 +1,28 @@
-﻿namespace FFMpegCore.Arguments
+﻿using FFMpegCore.Enums;
+
+namespace FFMpegCore.Arguments
 {
     /// <summary>
-    /// Represents choice of video stream
+    /// Represents choice of stream by the stream specifier 
     /// </summary>
     public class MapStreamArgument : IArgument
     {
         private readonly int _inputFileIndex;
         private readonly int _streamIndex;
+        private readonly Channel _channel;
 
-        public MapStreamArgument(int streamIndex, int inputFileIndex)
+        public MapStreamArgument(int streamIndex, int inputFileIndex, Channel channel = Channel.All)
         {
+            if (channel == Channel.Both)
+            {
+                // "Both" is not valid in this case and probably means all stream types
+                channel = Channel.All;
+            }
             _inputFileIndex = inputFileIndex;
             _streamIndex = streamIndex;
+            _channel = channel;
         }
 
-        public string Text => $"-map {_inputFileIndex}:{_streamIndex}";
+        public string Text => $"-map {_inputFileIndex}{_channel.StreamType()}:{_streamIndex}";
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/MapStreamArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/MapStreamArgument.cs
@@ -10,8 +10,9 @@ namespace FFMpegCore.Arguments
         private readonly int _inputFileIndex;
         private readonly int _streamIndex;
         private readonly Channel _channel;
+        private readonly bool _negativeMap;
 
-        public MapStreamArgument(int streamIndex, int inputFileIndex, Channel channel = Channel.All)
+        public MapStreamArgument(int streamIndex, int inputFileIndex, Channel channel = Channel.All, bool negativeMap = false)
         {
             if (channel == Channel.Both)
             {
@@ -21,8 +22,9 @@ namespace FFMpegCore.Arguments
             _inputFileIndex = inputFileIndex;
             _streamIndex = streamIndex;
             _channel = channel;
+            _negativeMap = negativeMap;
         }
 
-        public string Text => $"-map {_inputFileIndex}{_channel.StreamType()}:{_streamIndex}";
+        public string Text => $"-map {(_negativeMap?"-":"")}{_inputFileIndex}{_channel.StreamType()}:{_streamIndex}";
     }
 }

--- a/FFMpegCore/FFMpeg/Enums/Enums.cs
+++ b/FFMpegCore/FFMpeg/Enums/Enums.cs
@@ -46,10 +46,43 @@
         Aac_AdtstoAsc
     }
 
+    /// <summary>
+    /// https://ffmpeg.org/ffmpeg.html#Stream-specifiers-1
+    /// ’v’ or ’V’ for video, ’a’ for audio, ’s’ for subtitle, ’d’ for data, and ’t’ for attachments
+    /// ’V’ only matches video streams which are not attached pictures, video thumbnails or cover arts.
+    /// Both for audio + video
+    /// All for all types
+    /// </summary>
     public enum Channel
     {
         Audio,
         Video,
-        Both
+        Both,
+        VideoNoAttachedPic,
+        Subtitle,
+        Data,
+        Attachments,
+        All
     }
+    internal static class ChannelMethods
+    {
+        /// <summary>
+        /// <see cref="Channel.Both"/> is left as empty because it cannot be in a single stream specifier
+        /// </summary>
+        /// <returns>The stream_type used in stream specifiers</returns>
+        public static string StreamType(this Channel channel)
+        {
+            return channel switch
+            {
+                Channel.Audio => ":a",
+                Channel.Video => ":v",
+                Channel.VideoNoAttachedPic => ":V",
+                Channel.Subtitle => ":s",
+                Channel.Data => ":d",
+                Channel.Attachments => ":t",
+                _ => string.Empty
+            };
+        }
+    }
+
 }

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
-
+using System.Linq;
 using FFMpegCore.Arguments;
 using FFMpegCore.Enums;
 
@@ -61,6 +62,8 @@ namespace FFMpegCore
         public FFMpegArgumentOptions Loop(int times) => WithArgument(new LoopArgument(times));
         public FFMpegArgumentOptions OverwriteExisting() => WithArgument(new OverwriteArgument());
         public FFMpegArgumentOptions SelectStream(int streamIndex, int inputFileIndex = 0) => WithArgument(new MapStreamArgument(streamIndex, inputFileIndex));
+        public FFMpegArgumentOptions SelectStreams(IEnumerable<int> streamIndices, int inputFileIndex = 0) =>
+            streamIndices.Aggregate(this, (options, streamIndex) => options.SelectStream(streamIndex, inputFileIndex));
 
         public FFMpegArgumentOptions ForceFormat(ContainerFormat format) => WithArgument(new ForceFormatArgument(format));
         public FFMpegArgumentOptions ForceFormat(string format) => WithArgument(new ForceFormatArgument(format));

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -63,8 +63,14 @@ namespace FFMpegCore
         public FFMpegArgumentOptions OverwriteExisting() => WithArgument(new OverwriteArgument());
         public FFMpegArgumentOptions SelectStream(int streamIndex, int inputFileIndex = 0,
             Channel channel = Channel.All) => WithArgument(new MapStreamArgument(streamIndex, inputFileIndex, channel));
-        public FFMpegArgumentOptions SelectStreams(IEnumerable<int> streamIndices, int inputFileIndex = 0, Channel channel = Channel.All) =>
-            streamIndices.Aggregate(this, (options, streamIndex) => options.SelectStream(streamIndex, inputFileIndex, channel));
+        public FFMpegArgumentOptions SelectStreams(IEnumerable<int> streamIndices, int inputFileIndex = 0,
+            Channel channel = Channel.All) => streamIndices.Aggregate(this,
+            (options, streamIndex) => options.SelectStream(streamIndex, inputFileIndex, channel));
+        public FFMpegArgumentOptions DeselectStream(int streamIndex, int inputFileIndex = 0,
+            Channel channel = Channel.All) => WithArgument(new MapStreamArgument(streamIndex, inputFileIndex, channel, true));
+        public FFMpegArgumentOptions DeselectStreams(IEnumerable<int> streamIndices, int inputFileIndex = 0,
+            Channel channel = Channel.All) => streamIndices.Aggregate(this,
+            (options, streamIndex) => options.DeselectStream(streamIndex, inputFileIndex, channel));
 
         public FFMpegArgumentOptions ForceFormat(ContainerFormat format) => WithArgument(new ForceFormatArgument(format));
         public FFMpegArgumentOptions ForceFormat(string format) => WithArgument(new ForceFormatArgument(format));

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -61,9 +61,10 @@ namespace FFMpegCore
         public FFMpegArgumentOptions Seek(TimeSpan? seekTo) => WithArgument(new SeekArgument(seekTo));
         public FFMpegArgumentOptions Loop(int times) => WithArgument(new LoopArgument(times));
         public FFMpegArgumentOptions OverwriteExisting() => WithArgument(new OverwriteArgument());
-        public FFMpegArgumentOptions SelectStream(int streamIndex, int inputFileIndex = 0) => WithArgument(new MapStreamArgument(streamIndex, inputFileIndex));
-        public FFMpegArgumentOptions SelectStreams(IEnumerable<int> streamIndices, int inputFileIndex = 0) =>
-            streamIndices.Aggregate(this, (options, streamIndex) => options.SelectStream(streamIndex, inputFileIndex));
+        public FFMpegArgumentOptions SelectStream(int streamIndex, int inputFileIndex = 0,
+            Channel channel = Channel.All) => WithArgument(new MapStreamArgument(streamIndex, inputFileIndex, channel));
+        public FFMpegArgumentOptions SelectStreams(IEnumerable<int> streamIndices, int inputFileIndex = 0, Channel channel = Channel.All) =>
+            streamIndices.Aggregate(this, (options, streamIndex) => options.SelectStream(streamIndex, inputFileIndex, channel));
 
         public FFMpegArgumentOptions ForceFormat(ContainerFormat format) => WithArgument(new ForceFormatArgument(format));
         public FFMpegArgumentOptions ForceFormat(string format) => WithArgument(new ForceFormatArgument(format));


### PR DESCRIPTION
1. Populated the `Channel` enum with other stream types. See [ffmpeg docs](https://ffmpeg.org/ffmpeg.html#Stream-specifiers-1)
2. Added `SelectStreams` options to allow select multiple streams in one call from the user
3. Added `DeselectStream` and `DeselectStreams` for negative mapping. 