### PR TITLE
Fix hard-coded `/tmp` path on Linux

### DIFF
--- a/FFMpegCore/FFMpeg/Pipes/PipeHelpers.cs
+++ b/FFMpegCore/FFMpeg/Pipes/PipeHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace FFMpegCore.Pipes
@@ -12,7 +13,7 @@ namespace FFMpegCore.Pipes
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return $@"\\.\pipe\{pipeName}";
             else
-                return $"unix:/tmp/CoreFxPipe_{pipeName}";
+                return $"unix:{Path.GetTempPath()}CoreFxPipe_{pipeName}";
         }
     }
 }


### PR DESCRIPTION
On some environments (ci/cd, etc) the default temp folder on Linux is not `/tmp`. The standard way of determining the temp folder for any platform is using the `Path.GetTempPath` method, which will take Environment variables into account (see [Path.GetTempPath Method (System.IO) | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.gettemppath?view=net-7.0&tabs=linux))