### PR TITLE
Short socket names to prevent 104 char limit

### DIFF
--- a/FFMpegCore/FFMpeg/Pipes/PipeHelpers.cs
+++ b/FFMpegCore/FFMpeg/Pipes/PipeHelpers.cs
@@ -5,7 +5,7 @@ namespace FFMpegCore.Pipes
 {
     static class PipeHelpers
     {
-        public static string GetUnqiuePipeName() => $"FFMpegCore_{Guid.NewGuid()}";
+        public static string GetUnqiuePipeName() => $"FFMpegCore_{Guid.NewGuid().ToString("N").Substring(0, 5)}";
 
         public static string GetPipePath(string pipeName)
         {

--- a/FFMpegCore/FFMpeg/Pipes/PipeHelpers.cs
+++ b/FFMpegCore/FFMpeg/Pipes/PipeHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace FFMpegCore.Pipes
@@ -11,8 +12,9 @@ namespace FFMpegCore.Pipes
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return $@"\\.\pipe\{pipeName}";
-            else
-                return $"unix:/tmp/CoreFxPipe_{pipeName}";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return $"unix:{Path.GetTempPath()}/CoreFxPipe_{pipeName}";
+            return $"unix:/tmp/CoreFxPipe_{pipeName}";
         }
     }
 }


### PR DESCRIPTION
Bug fix that prevents FFMpegCore to run on MacOS.
Discussed at https://github.com/rosenbjerg/FFMpegCore/issues/365