### PR TITLE
-PosterWithAudio has duration parameter in seconds if audio is IsNull…

### DIFF
--- a/FFMpegCore.Examples/Program.cs
+++ b/FFMpegCore.Examples/Program.cs
@@ -5,18 +5,27 @@ using FFMpegCore.Extensions.SkiaSharp;
 using FFMpegCore.Extensions.System.Drawing.Common;
 using FFMpegCore.Pipes;
 using SkiaSharp;
+using FFMpegCore.Helpers;
 using FFMpegImage = FFMpegCore.Extensions.System.Drawing.Common.FFMpegImage;
 
 var inputPath = "/path/to/input";
 var outputPath = "/path/to/output";
+//var inputPathJpg = "/path/to/input.jpg";
+//var inputPathMp3 = "/path/to/input.mp3";
+//var outputPathMp4 = "/path/to/output.mp4";
 
 {
+    FFMpegHelper.VerifyFFMpegExists(new FFOptions());
     var mediaInfo = FFProbe.Analyse(inputPath);
 }
 
 {
     var mediaInfo = await FFProbe.AnalyseAsync(inputPath);
 }
+
+//{
+//   FFMpeg.PosterWithAudio(inputPathJpg, inputPathMp3, outPathMp4, 0, 5);
+//}
 
 {
     FFMpegArguments

--- a/FFMpegCore/FFMpeg/Arguments/RotateArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/RotateArgument.cs
@@ -1,6 +1,4 @@
-﻿using System.Drawing;
-
-namespace FFMpegCore.Arguments
+﻿namespace FFMpegCore.Arguments
 {
     /// <summary>
     /// Represents size parameter

--- a/FFMpegCore/FFMpeg/Arguments/RotateArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/RotateArgument.cs
@@ -1,0 +1,25 @@
+﻿using System.Drawing;
+
+namespace FFMpegCore.Arguments
+{
+    /// <summary>
+    /// Represents size parameter
+    /// </summary>
+    public class RotateArgument : IArgument
+    {
+        public readonly int Rotate;
+        public RotateArgument(int arg)
+        {
+            Rotate = arg;
+        }
+
+        public string Text => Rotate switch
+        {
+           0 => $"",
+           1 => $"-vf \"transpose=1\"",
+           2 => $"-vf \"transpose=1, transpose=1\"",
+           3 => $"-vf \"transpose=1, transpose=1, transpose=1\"",
+           _ => throw new System.ArgumentOutOfRangeException(nameof(RotateArgument))
+        };
+    }
+}

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -122,6 +122,7 @@ namespace FFMpegCore
             var analysis = FFProbe.Analyse(image);
             FFMpegHelper.ConversionSizeExceptionCheck(analysis.PrimaryVideoStream!.Width, analysis.PrimaryVideoStream!.Height);
             if (string.IsNullOrEmpty(audio))
+            {
                return FFMpegArguments
                   .FromFileInput(image, false, options => options
                                  .Loop(1)
@@ -134,20 +135,23 @@ namespace FFMpegCore
                                 .WithDuration(new TimeSpan(0,0,duration))
                                 .WithArgument(new RotateArgument(rotateX90)))
                   .ProcessSynchronously();
+            }
             else
-            return FFMpegArguments
-                .FromFileInput(image, false, options => options
-                    .Loop(1)
-                    .ForceFormat("image2"))
-                .AddFileInput(audio)
-                .OutputToFile(output, true, options => options
-                    .ForcePixelFormat("yuv420p")
-                    .WithVideoCodec(VideoCodec.LibX264)
-                    .WithConstantRateFactor(21)
-                    .WithAudioBitrate(AudioQuality.Normal)
-                    .UsingShortest()
-                    .WithArgument(new RotateArgument(rotateX90)))
-                .ProcessSynchronously();
+            {
+               return FFMpegArguments
+                  .FromFileInput(image, false, options => options
+                                 .Loop(1)
+                                 .ForceFormat("image2"))
+                  .AddFileInput(audio)
+                  .OutputToFile(output, true, options => options
+                                .ForcePixelFormat("yuv420p")
+                                .WithVideoCodec(VideoCodec.LibX264)
+                                .WithConstantRateFactor(21)
+                                .WithAudioBitrate(AudioQuality.Normal)
+                                .UsingShortest()
+                                .WithArgument(new RotateArgument(rotateX90)))
+                  .ProcessSynchronously();
+            }
         }
 
         /// <summary>

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -3,9 +3,12 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Description>A .NET Standard FFMpeg/FFProbe wrapper for easily integrating media analysis and conversion into your .NET applications</Description>
-    <PackageVersion>5.0.2</PackageVersion>
+    <PackageVersion>5.0.3</PackageVersion>
     <PackageOutputPath>../nupkg</PackageOutputPath>
-    <PackageReleaseNotes>
+    <PackageReleaseNotes>-Charles Young:
+-PosterWithAudio has duration parameter in seconds if audio is IsNullOrEmpty
+-PosterWithAudio has new rotateX90 parameter (0, 1, 2, or 3)
+-VerifyFFMpegExists fixed to work with both Windows and Mac
     </PackageReleaseNotes>
     <PackageTags>ffmpeg ffprobe convert video audio mediafile resize analyze muxing</PackageTags>
     <Authors>Malte Rosenbjerg, Vlad Jerca, Max Bagryantsev</Authors>

--- a/FFMpegCore/Helpers/FFMpegHelper.cs
+++ b/FFMpegCore/Helpers/FFMpegHelper.cs
@@ -37,18 +37,26 @@ namespace FFMpegCore.Helpers
 
         public static void VerifyFFMpegExists(FFOptions ffMpegOptions)
         {
-            if (_ffmpegVerified) return;
+            if (_ffmpegVerified)
+            {
+               return;
+            }
+
             try
             {
                var result = Instance.Finish(GlobalFFOptions.GetFFMpegBinaryPath(ffMpegOptions), "-version");
                _ffmpegVerified = result.ExitCode == 0;
             }
+
             catch (Exception)
             {
                _ffmpegVerified = false;
             }
-            if (!_ffmpegVerified) 
+
+            if (!_ffmpegVerified)
+            {
                 throw new FFMpegException(FFMpegExceptionType.Operation, "ffmpeg was not found on your system");
+            }
         }
     }
 }

--- a/FFMpegCore/Helpers/FFMpegHelper.cs
+++ b/FFMpegCore/Helpers/FFMpegHelper.cs
@@ -37,17 +37,18 @@ namespace FFMpegCore.Helpers
 
         public static void VerifyFFMpegExists(FFOptions ffMpegOptions)
         {
-            if (_ffmpegVerified)
+            if (_ffmpegVerified) return;
+            try
             {
-                return;
+               var result = Instance.Finish(GlobalFFOptions.GetFFMpegBinaryPath(ffMpegOptions), "-version");
+               _ffmpegVerified = result.ExitCode == 0;
             }
-
-            var result = Instance.Finish(GlobalFFOptions.GetFFMpegBinaryPath(ffMpegOptions), "-version");
-            _ffmpegVerified = result.ExitCode == 0;
-            if (!_ffmpegVerified)
+            catch (Exception)
             {
+               _ffmpegVerified = false;
+            }
+            if (!_ffmpegVerified) 
                 throw new FFMpegException(FFMpegExceptionType.Operation, "ffmpeg was not found on your system");
-            }
         }
     }
 }


### PR DESCRIPTION
These are a few changes that I needed for my app that works on both Windows and Mac.

-PosterWithAudio has duration parameter in seconds if audio is IsNullOrEmpty
-PosterWithAudio has new rotateX90 parameter (0, 1, 2, or 3)
-VerifyFFMpegExists fixed to work with both Windows and Mac

My intent was that these changes should not affect existing users unless they want to take advantage of the new features.