### PR TITLE
configure custom ffmpeg/ffprobe binary names

### DIFF
--- a/FFMpegCore/FFOptions.cs
+++ b/FFMpegCore/FFOptions.cs
@@ -16,6 +16,16 @@ namespace FFMpegCore
         public string BinaryFolder { get; set; } = string.Empty;
 
         /// <summary>
+        /// Custom name for ffmpeg binary
+        /// </summary>
+        public string FFMpegBinaryName { get; set; } = "FFMpeg";
+
+        /// <summary>
+        /// Custom name for ffprobe binary
+        /// </summary>
+        public string FFProbeBinaryName { get; set; } = "FFProbe";
+
+        /// <summary>
         /// Folder used for temporary files necessary for static methods on FFMpeg class
         /// </summary>
         public string TemporaryFilesFolder { get; set; } = Path.GetTempPath();

--- a/FFMpegCore/GlobalFFOptions.cs
+++ b/FFMpegCore/GlobalFFOptions.cs
@@ -23,6 +23,13 @@ namespace FFMpegCore
 
         private static string GetFFBinaryPath(string name, FFOptions ffOptions)
         {
+            name = name switch
+            {
+                "FFMpeg" => ffOptions.FFMpegBinaryName,
+                "FFProbe" => ffOptions.FFProbeBinaryName,
+                _ => throw new ArgumentException(nameof(name))
+            };
+
             var ffName = name.ToLowerInvariant();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {


### PR DESCRIPTION
Allows you to use custom binary names like "ffmpeg_x64" or "ffprobe_x86"