### PR TITLE
Add a helper method to generate GIF Snapshots

### DIFF
--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -540,7 +540,7 @@ namespace FFMpegCore.Test
         }
 
         [TestMethod]
-        public void Builder_BuildString_GifPallet()
+        public void Builder_BuildString_GifPalette()
         {
             var streamIndex = 0;
             var size = new Size(640, 480);
@@ -548,7 +548,7 @@ namespace FFMpegCore.Test
             var str = FFMpegArguments
                 .FromFileInput("input.mp4")
                 .OutputToFile("output.gif", false, opt => opt
-                    .WithGifPalettArgument(streamIndex, size))
+                    .WithGifPaletteArgument(streamIndex, size))
                 .Arguments;
 
             Assert.AreEqual($"""
@@ -557,14 +557,14 @@ namespace FFMpegCore.Test
         }
 
         [TestMethod]
-        public void Builder_BuildString_GifPallet_NullSize_FpsSupplied()
+        public void Builder_BuildString_GifPalette_NullSize_FpsSupplied()
         {
             var streamIndex = 1;
 
             var str = FFMpegArguments
                 .FromFileInput("input.mp4")
                 .OutputToFile("output.gif", false, opt => opt
-                    .WithGifPalettArgument(streamIndex, null, 10))
+                    .WithGifPaletteArgument(streamIndex, null, 10))
                 .Arguments;
 
             Assert.AreEqual($"""

--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -1,4 +1,5 @@
-﻿using FFMpegCore.Arguments;
+﻿using System.Drawing;
+using FFMpegCore.Arguments;
 using FFMpegCore.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -536,6 +537,39 @@ namespace FFMpegCore.Test
             Assert.AreEqual(
                 "-i \"input.mp4\" -vf \"pad=aspect=4/3:x=(ow-iw)/2:y=(oh-ih)/2:color=violet:eval=frame\" \"output.mp4\"",
                 str);
+        }
+
+        [TestMethod]
+        public void Builder_BuildString_GifPallet()
+        {
+            var streamIndex = 0;
+            var size = new Size(640, 480);
+
+            var str = FFMpegArguments
+                .FromFileInput("input.mp4")
+                .OutputToFile("output.gif", false, opt => opt
+                    .WithGifPalettArgument(streamIndex, size))
+                .Arguments;
+
+            Assert.AreEqual($"""
+                -i "input.mp4" -filter_complex "[0:v] fps=12,scale=w={size.Width}:h={size.Height},split [a][b];[a] palettegen=max_colors=32 [p];[b][p] paletteuse=dither=bayer" "output.gif"
+                """, str);
+        }
+
+        [TestMethod]
+        public void Builder_BuildString_GifPallet_NullSize_FpsSupplied()
+        {
+            var streamIndex = 1;
+
+            var str = FFMpegArguments
+                .FromFileInput("input.mp4")
+                .OutputToFile("output.gif", false, opt => opt
+                    .WithGifPalettArgument(streamIndex, null, 10))
+                .Arguments;
+
+            Assert.AreEqual($"""
+                -i "input.mp4" -filter_complex "[{streamIndex}:v] fps=10,split [a][b];[a] palettegen=max_colors=32 [p];[b][p] paletteuse=dither=bayer" "output.gif"
+                """, str);
         }
     }
 }

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing.Imaging;
+﻿using System.Drawing;
+using System.Drawing.Imaging;
 using System.Runtime.Versioning;
 using System.Text;
 using FFMpegCore.Arguments;
@@ -477,6 +478,64 @@ namespace FFMpegCore.Test
             Assert.AreEqual(input.PrimaryVideoStream!.Width, analysis.PrimaryVideoStream!.Width);
             Assert.AreEqual(input.PrimaryVideoStream.Height, analysis.PrimaryVideoStream!.Height);
             Assert.AreEqual("png", analysis.PrimaryVideoStream!.CodecName);
+        }
+
+        [TestMethod, Timeout(BaseTimeoutMilliseconds)]
+        public void Video_GifSnapshot_PersistSnapshot()
+        {
+            using var outputPath = new TemporaryFile("out.gif");
+            var input = FFProbe.Analyse(TestResources.Mp4Video);
+
+            FFMpeg.GifSnapshot(TestResources.Mp4Video, outputPath, captureTime: TimeSpan.FromSeconds(0));
+
+            var analysis = FFProbe.Analyse(outputPath);
+            Assert.AreNotEqual(input.PrimaryVideoStream!.Width, analysis.PrimaryVideoStream!.Width);
+            Assert.AreNotEqual(input.PrimaryVideoStream.Height, analysis.PrimaryVideoStream!.Height);
+            Assert.AreEqual("gif", analysis.PrimaryVideoStream!.CodecName);
+        }
+
+        [TestMethod, Timeout(BaseTimeoutMilliseconds)]
+        public void Video_GifSnapshot_PersistSnapshot_SizeSupplied()
+        {
+            using var outputPath = new TemporaryFile("out.gif");
+            var input = FFProbe.Analyse(TestResources.Mp4Video);
+            var desiredGifSize = new Size(320, 240);
+
+            FFMpeg.GifSnapshot(TestResources.Mp4Video, outputPath, desiredGifSize, captureTime: TimeSpan.FromSeconds(0));
+
+            var analysis = FFProbe.Analyse(outputPath);
+            Assert.AreNotEqual(input.PrimaryVideoStream!.Width, desiredGifSize.Width);
+            Assert.AreNotEqual(input.PrimaryVideoStream.Height, desiredGifSize.Height);
+            Assert.AreEqual("gif", analysis.PrimaryVideoStream!.CodecName);
+        }
+
+        [TestMethod, Timeout(BaseTimeoutMilliseconds)]
+        public async Task Video_GifSnapshot_PersistSnapshotAsync()
+        {
+            using var outputPath = new TemporaryFile("out.gif");
+            var input = FFProbe.Analyse(TestResources.Mp4Video);
+
+            await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, captureTime: TimeSpan.FromSeconds(0));
+
+            var analysis = FFProbe.Analyse(outputPath);
+            Assert.AreNotEqual(input.PrimaryVideoStream!.Width, analysis.PrimaryVideoStream!.Width);
+            Assert.AreNotEqual(input.PrimaryVideoStream.Height, analysis.PrimaryVideoStream!.Height);
+            Assert.AreEqual("gif", analysis.PrimaryVideoStream!.CodecName);
+        }
+
+        [TestMethod, Timeout(BaseTimeoutMilliseconds)]
+        public async Task Video_GifSnapshot_PersistSnapshotAsync_SizeSupplied()
+        {
+            using var outputPath = new TemporaryFile("out.gif");
+            var input = FFProbe.Analyse(TestResources.Mp4Video);
+            var desiredGifSize = new Size(320, 240);
+
+            await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, desiredGifSize, captureTime: TimeSpan.FromSeconds(0));
+
+            var analysis = FFProbe.Analyse(outputPath);
+            Assert.AreNotEqual(input.PrimaryVideoStream!.Width, desiredGifSize.Width);
+            Assert.AreNotEqual(input.PrimaryVideoStream.Height, desiredGifSize.Height);
+            Assert.AreEqual("gif", analysis.PrimaryVideoStream!.CodecName);
         }
 
         [TestMethod, Timeout(BaseTimeoutMilliseconds)]

--- a/FFMpegCore/FFMpeg/Arguments/GifPalettArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/GifPalettArgument.cs
@@ -4,18 +4,21 @@ namespace FFMpegCore.Arguments
 {
     public class GifPalettArgument : IArgument
     {
+        private readonly int _streamIndex;
+
         private readonly int _fps;
 
         private readonly Size? _size;
 
-        public GifPalettArgument(int fps, Size? size)
+        public GifPalettArgument(int streamIndex, int fps, Size? size)
         {
+            _streamIndex = streamIndex;
             _fps = fps;
             _size = size;
         }
 
         private string ScaleText => _size.HasValue ? $"scale=w={_size.Value.Width}:h={_size.Value.Height}," : string.Empty;
 
-        public string Text => $"-filter_complex \"[0:v] fps={_fps},{ScaleText}split [a][b];[a] palettegen=max_colors=32 [p];[b][p] paletteuse=dither=bayer\"";
+        public string Text => $"-filter_complex \"[{_streamIndex}:v] fps={_fps},{ScaleText}split [a][b];[a] palettegen=max_colors=32 [p];[b][p] paletteuse=dither=bayer\"";
     }
 }

--- a/FFMpegCore/FFMpeg/Arguments/GifPalettArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/GifPalettArgument.cs
@@ -1,0 +1,21 @@
+﻿using System.Drawing;
+
+namespace FFMpegCore.Arguments
+{
+    public class GifPalettArgument : IArgument
+    {
+        private readonly int _fps;
+
+        private readonly Size? _size;
+
+        public GifPalettArgument(int fps, Size? size)
+        {
+            _fps = fps;
+            _size = size;
+        }
+
+        private string ScaleText => _size.HasValue ? $"scale=w={_size.Value.Width}:h={_size.Value.Height}," : string.Empty;
+
+        public string Text => $"-filter_complex \"[0:v] fps={_fps},{ScaleText}split [a][b];[a] palettegen=max_colors=32 [p];[b][p] paletteuse=dither=bayer\"";
+    }
+}

--- a/FFMpegCore/FFMpeg/Arguments/GifPaletteArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/GifPaletteArgument.cs
@@ -2,7 +2,7 @@
 
 namespace FFMpegCore.Arguments
 {
-    public class GifPalettArgument : IArgument
+    public class GifPaletteArgument : IArgument
     {
         private readonly int _streamIndex;
 
@@ -10,7 +10,7 @@ namespace FFMpegCore.Arguments
 
         private readonly Size? _size;
 
-        public GifPalettArgument(int streamIndex, int fps, Size? size)
+        public GifPaletteArgument(int streamIndex, int fps, Size? size)
         {
             _streamIndex = streamIndex;
             _fps = fps;

--- a/FFMpegCore/FFMpeg/Enums/FileExtension.cs
+++ b/FFMpegCore/FFMpeg/Enums/FileExtension.cs
@@ -20,5 +20,6 @@
         public static readonly string WebM = VideoType.WebM.Extension;
         public static readonly string Png = ".png";
         public static readonly string Mp3 = ".mp3";
+        public static readonly string Gif = ".gif";
     }
 }

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -57,6 +57,36 @@ namespace FFMpegCore
                 .ProcessAsynchronously();
         }
 
+        public static bool GifSnapshot(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null, int ? streamIndex = null)
+        {
+            if (Path.GetExtension(output)?.ToLower() != FileExtension.Gif)
+            {
+                output = Path.Combine(Path.GetDirectoryName(output), Path.GetFileNameWithoutExtension(output) + FileExtension.Gif);
+            }
+
+            var source = FFProbe.Analyse(input);
+            var (arguments, outputOptions) = SnapshotArgumentBuilder.BuildGifSnapshotArguments(input, source, size, captureTime, duration, streamIndex);
+
+            return arguments
+                .OutputToFile(output, true, outputOptions)
+                .ProcessSynchronously();
+        }
+
+        public static async Task<bool> GifSnapshotAsync(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null, int? streamIndex = null)
+        {
+            if (Path.GetExtension(output)?.ToLower() != FileExtension.Gif)
+            {
+                output = Path.Combine(Path.GetDirectoryName(output), Path.GetFileNameWithoutExtension(output) + FileExtension.Gif);
+            }
+
+            var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
+            var (arguments, outputOptions) = SnapshotArgumentBuilder.BuildGifSnapshotArguments(input, source, size, captureTime, duration, streamIndex);
+
+            return await arguments
+                .OutputToFile(output, true, outputOptions)
+                .ProcessAsynchronously();
+        }
+
         /// <summary>
         /// Converts an image sequence to a video.
         /// </summary>

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -57,7 +57,7 @@ namespace FFMpegCore
                 .ProcessAsynchronously();
         }
 
-        public static bool GifSnapshot(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null, int ? streamIndex = null)
+        public static bool GifSnapshot(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null, int? streamIndex = null)
         {
             if (Path.GetExtension(output)?.ToLower() != FileExtension.Gif)
             {

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -76,7 +76,7 @@ namespace FFMpegCore
         public FFMpegArgumentOptions WithAudibleEncryptionKeys(string key, string iv) => WithArgument(new AudibleEncryptionKeyArgument(key, iv));
         public FFMpegArgumentOptions WithAudibleActivationBytes(string activationBytes) => WithArgument(new AudibleEncryptionKeyArgument(activationBytes));
         public FFMpegArgumentOptions WithTagVersion(int id3v2Version = 3) => WithArgument(new ID3V2VersionArgument(id3v2Version));
-        public FFMpegArgumentOptions WithGifPalettArgument(int streamIndex, Size? size, int fps = 12) => WithArgument(new GifPalettArgument(streamIndex, fps, size));
+        public FFMpegArgumentOptions WithGifPaletteArgument(int streamIndex, Size? size, int fps = 12) => WithArgument(new GifPaletteArgument(streamIndex, fps, size));
 
         public FFMpegArgumentOptions WithArgument(IArgument argument)
         {

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -76,6 +76,7 @@ namespace FFMpegCore
         public FFMpegArgumentOptions WithAudibleEncryptionKeys(string key, string iv) => WithArgument(new AudibleEncryptionKeyArgument(key, iv));
         public FFMpegArgumentOptions WithAudibleActivationBytes(string activationBytes) => WithArgument(new AudibleEncryptionKeyArgument(activationBytes));
         public FFMpegArgumentOptions WithTagVersion(int id3v2Version = 3) => WithArgument(new ID3V2VersionArgument(id3v2Version));
+        public FFMpegArgumentOptions WithGifPalettArgument(Size? size, int fps = 12) => WithArgument(new GifPalettArgument(fps, size));
 
         public FFMpegArgumentOptions WithArgument(IArgument argument)
         {

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -76,7 +76,7 @@ namespace FFMpegCore
         public FFMpegArgumentOptions WithAudibleEncryptionKeys(string key, string iv) => WithArgument(new AudibleEncryptionKeyArgument(key, iv));
         public FFMpegArgumentOptions WithAudibleActivationBytes(string activationBytes) => WithArgument(new AudibleEncryptionKeyArgument(activationBytes));
         public FFMpegArgumentOptions WithTagVersion(int id3v2Version = 3) => WithArgument(new ID3V2VersionArgument(id3v2Version));
-        public FFMpegArgumentOptions WithGifPalettArgument(Size? size, int fps = 12) => WithArgument(new GifPalettArgument(fps, size));
+        public FFMpegArgumentOptions WithGifPalettArgument(int streamIndex, Size? size, int fps = 12) => WithArgument(new GifPalettArgument(streamIndex, fps, size));
 
         public FFMpegArgumentOptions WithArgument(IArgument argument)
         {

--- a/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
+++ b/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
@@ -53,7 +53,7 @@ public static class SnapshotArgumentBuilder
                     .Seek(captureTime)
                     .WithDuration(duration)),
             options => options
-                .WithGifPalettArgument((int)streamIndex, size, fps));
+                .WithGifPaletteArgument((int)streamIndex, size, fps));
     }
 
     private static Size? PrepareSnapshotSize(IMediaAnalysis source, Size? wantedSize)

--- a/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
+++ b/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
@@ -31,6 +31,31 @@ public static class SnapshotArgumentBuilder
                 .Resize(size));
     }
 
+    public static (FFMpegArguments, Action<FFMpegArgumentOptions> outputOptions) BuildGifSnapshotArguments(
+        string input,
+        IMediaAnalysis source,
+        Size? size = null,
+        TimeSpan? captureTime = null,
+        TimeSpan? duration = null,
+        int? streamIndex = null,
+        int fps = 12)
+    {
+        var defaultGifOutputSize = new Size(480, -1);
+
+        captureTime ??= TimeSpan.FromSeconds(source.Duration.TotalSeconds / 3);
+        size = PrepareSnapshotSize(source, size) ?? defaultGifOutputSize;
+        streamIndex ??= source.PrimaryVideoStream?.Index
+                        ?? source.VideoStreams.FirstOrDefault()?.Index
+                        ?? 0;
+
+        return (FFMpegArguments
+                .FromFileInput(input, false, options => options
+                    .Seek(captureTime)
+                    .WithDuration(duration)),
+            options => options
+                .WithGifPalettArgument((int)streamIndex, size, fps));
+    }
+
     private static Size? PrepareSnapshotSize(IMediaAnalysis source, Size? wantedSize)
     {
         if (wantedSize == null || (wantedSize.Value.Height <= 0 && wantedSize.Value.Width <= 0) || source.PrimaryVideoStream == null)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ var bitmap = FFMpeg.Snapshot(inputPath, new Size(200, 400), TimeSpan.FromMinutes
 FFMpeg.Snapshot(inputPath, outputPath, new Size(200, 400), TimeSpan.FromMinutes(1));
 ```
 
+### You can also capture GIF snapshots from a video file:
+```csharp
+FFMpeg.GifSnapshot(inputPath, outputPath, new Size(200, 400), TimeSpan.FromSeconds(10));
+
+// or async
+await FFMpeg.GifSnapshotAsync(inputPath, outputPath, new Size(200, 400), TimeSpan.FromSeconds(10));
+
+// you can also supply -1 to either one of Width/Height Size properties if you'd like FFMPEG to resize while maintaining the aspect ratio
+await FFMpeg.GifSnapshotAsync(inputPath, outputPath, new Size(480, -1), TimeSpan.FromSeconds(10));
+```
+
 ### Join video parts into one single file:
 ```csharp
 FFMpeg.Join(@"..\joined_video.mp4",


### PR DESCRIPTION
These changes add a helper method to generate GIF snapshots. Here is an example output of the `input_3sec.mp4` resource test file with default parameters:

![81877f52-a2f6-44bf-be33-e4fc5fda7950-out](https://user-images.githubusercontent.com/12396249/223316226-8656e1b9-237b-4965-943a-a6259e48108c.gif)
