### PR TITLE
Ability to install ffmpeg suite at runtime added with FFMpegDownloader

### DIFF
--- a/FFMpegCore.Test/DownloaderTests.cs
+++ b/FFMpegCore.Test/DownloaderTests.cs
@@ -1,27 +1,65 @@
 ﻿using System.Runtime.InteropServices;
 using FFMpegCore.Helpers;
-
-namespace FFMpegCore.Test;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+namespace FFMpegCore.Test;
+
+[TestClass]
 public class DownloaderTests
 {
-    [TestClass]
-    public class FFMpegDownloaderTest
+    [TestMethod]
+    public void GetLatestSuiteTest()
     {
-        [TestMethod]
-        public void GetLatestVersionTest()
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                var files = FFMpegDownloader.GetLatestVersion();
-                Assert.IsTrue(files.Count == 3);
-            }
-            else
-            {
-                Assert.Inconclusive("This test is only for Windows");
-            }
-            
+            var fileNames = FFMpegDownloader.AutoDownloadFFMpegSuite();
+            Assert.IsTrue(fileNames.Count == 3);
+        }
+        else
+        {
+            Assert.Inconclusive("This test is only for Windows");
+        }
+    }
+    
+    [TestMethod]
+    public void GetLatestFFMpegTest()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var fileNames = FFMpegDownloader.AutoDownloadFFMpeg();
+            Assert.IsTrue(fileNames.Count == 1);
+        }
+        else
+        {
+            Assert.Inconclusive("This test is only for Windows");
+        }
+    }
+    
+    [TestMethod]
+    public void GetLatestFFProbeTest()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var fileNames = FFMpegDownloader.AutoDownloadFFProbe();
+            Assert.IsTrue(fileNames.Count == 1);
+        }
+        else
+        {
+            Assert.Inconclusive("This test is only for Windows");
+        }
+    }
+    
+    [TestMethod]
+    public void GetLatestFFPlayTest()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var fileNames = FFMpegDownloader.AutoDownloadFFPlay();
+            Assert.IsTrue(fileNames.Count == 1);
+        }
+        else
+        {
+            Assert.Inconclusive("This test is only for Windows");
         }
     }
 }

--- a/FFMpegCore.Test/DownloaderTests.cs
+++ b/FFMpegCore.Test/DownloaderTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.InteropServices;
+using FFMpegCore.Helpers;
+
+namespace FFMpegCore.Test;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+public class DownloaderTests
+{
+    [TestClass]
+    public class FFMpegDownloaderTest
+    {
+        [TestMethod]
+        public void GetLatestVersionTest()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var files = FFMpegDownloader.GetLatestVersion();
+                Assert.IsTrue(files.Count == 3);
+            }
+            else
+            {
+                Assert.Inconclusive("This test is only for Windows");
+            }
+            
+        }
+    }
+}

--- a/FFMpegCore/Helpers/FFMpegDownloader.cs
+++ b/FFMpegCore/Helpers/FFMpegDownloader.cs
@@ -1,0 +1,64 @@
+﻿using System.ComponentModel;
+using System.Net;
+using System.IO;
+using System.IO.Compression;
+
+
+namespace FFMpegCore.Helpers;
+using System.Runtime.InteropServices;
+
+/// <summary>
+/// Downloads the latest FFMpeg binaries from GitHub. Only supported for windows at the moment.
+/// </summary>
+public class FFMpegDownloader // this class is built to be easily modified to support other platforms
+{
+    /// <summary>
+    /// List of URLs to download FFMpeg from.
+    /// </summary>
+    private static Dictionary<string, string> FFMpegDownloadUrls = new()
+    {
+        { "windows", "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip" }
+    };
+
+    public static List<string> GetLatestVersion()
+    {
+        var os = GetOSPlatform();
+        var zipStream = DownloadFFMpeg(new Uri(FFMpegDownloadUrls[os]));
+        return ExtractAndSave(zipStream);
+    }
+
+    private static MemoryStream DownloadFFMpeg(Uri address)
+    {
+        var client = new WebClient();
+        var zipStream = new MemoryStream(client.DownloadData(address));
+        zipStream.Position = 0;
+
+        return zipStream;
+    }
+    
+    private static List<string> ExtractAndSave(Stream zipStream)
+    {
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        List<string> files = new();
+        foreach (var entry in archive.Entries)
+        {
+            if (entry.Name is "ffmpeg.exe" or "ffmpeg" or "ffprobe.exe")
+            {
+                entry.ExtractToFile(Path.Combine(GlobalFFOptions.Current.BinaryFolder, entry.Name), true);
+                files.Add(Path.Combine(GlobalFFOptions.Current.BinaryFolder, entry.Name));
+            }
+        }
+
+        return files;
+    }
+    
+    private static string GetOSPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "windows";
+        }
+
+        throw new PlatformNotSupportedException("Auto download is only supported on Windows.");
+    }
+}

--- a/FFMpegCore/Helpers/FFMpegDownloader.cs
+++ b/FFMpegCore/Helpers/FFMpegDownloader.cs
@@ -8,26 +8,95 @@ namespace FFMpegCore.Helpers;
 using System.Runtime.InteropServices;
 
 /// <summary>
-/// Downloads the latest FFMpeg binaries from GitHub. Only supported for windows at the moment.
+/// Downloads the latest FFMpeg suite binaries from GitHub. Only supported for windows at the moment.
 /// </summary>
 public class FFMpegDownloader // this class is built to be easily modified to support other platforms
 {
-    /// <summary>
-    /// List of URLs to download FFMpeg from.
-    /// </summary>
-    private static Dictionary<string, string> FFMpegDownloadUrls = new()
+    private static Dictionary<FFMpegVersions, string> Windows64FFMpegDownloadUrls = new()
     {
-        { "windows", "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip" }
+        { FFMpegVersions.V4_4_1, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.4.1/ffmpeg-4.4.1-win-64.zip"},
+        { FFMpegVersions.V4_2_1, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.2.1/ffmpeg-4.2.1-win-64.zip"},
+        { FFMpegVersions.V4_2, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.2/ffmpeg-4.2-win-64.zip"},
+        { FFMpegVersions.V4_1, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.1/ffmpeg-4.1-win-64.zip"},
+        { FFMpegVersions.V4_0, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.0/ffmpeg-4.0.1-win-64.zip"},
+        { FFMpegVersions.V3_4, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v3.4/ffmpeg-3.4-win-64.zip"},
+        { FFMpegVersions.V3_3, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v3.3/ffmpeg-3.3.4-win-64.zip"},
+        { FFMpegVersions.V3_2, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v3.2/ffmpeg-3.2-win-64.zip"},
     };
-
-    public static List<string> GetLatestVersion()
+    
+    private static Dictionary<FFMpegVersions, string> Windows32FFMpegDownloadUrls = new()
     {
-        var os = GetOSPlatform();
-        var zipStream = DownloadFFMpeg(new Uri(FFMpegDownloadUrls[os]));
+        { FFMpegVersions.V4_4_1, "https://example.com/" },
+        { FFMpegVersions.V4_2_1, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.2.1/ffmpeg-4.2.1-win-32.zip"},
+        { FFMpegVersions.V4_2, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.2/ffmpeg-4.2-win-32.zip"},
+        { FFMpegVersions.V4_1, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.1/ffmpeg-4.1-win-32.zip"},
+        { FFMpegVersions.V4_0, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.0/ffmpeg-4.0.1-win-32.zip"},
+        { FFMpegVersions.V3_4, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v3.4/ffmpeg-3.4-win-32.zip"},
+        { FFMpegVersions.V3_3, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v3.3/ffmpeg-3.3.4-win-32.zip"},
+        { FFMpegVersions.V3_2, "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v3.2/ffmpeg-3.2-win-32.zip"},
+    };
+    
+    public enum FFMpegVersions
+    {
+        V4_4_1,
+        V4_2_1,
+        V4_2,
+        V4_1,
+        V4_0,
+        V3_4,
+        V3_3,
+        V3_2
+    }
+
+    public static List<string> AutoDownloadFFMpegSuite(FFMpegVersions version = FFMpegVersions.V4_4_1)
+    {
+        var files = AutoDownloadFFMpeg(version);
+        files.AddRange(AutoDownloadFFProbe(version));
+        files.AddRange(AutoDownloadFFPlay(version));
+        
+        return files;
+    }
+
+    public static List<string> AutoDownloadFFMpeg(FFMpegVersions version = FFMpegVersions.V4_4_1)
+    {
+        var url = Environment.Is64BitProcess
+            ? new Uri(Windows64FFMpegDownloadUrls[version])
+            : new Uri(Windows32FFMpegDownloadUrls[version]);
+        
+        HasValidUri(url);
+
+        Stream zipStream = DownloadZip(url);
+
+        return ExtractAndSave(zipStream);
+    }
+    
+    public static List<string> AutoDownloadFFProbe(FFMpegVersions version = FFMpegVersions.V4_4_1)
+    {
+        var url = Environment.Is64BitProcess
+            ? new Uri(Windows64FFMpegDownloadUrls[version].Replace("ffmpeg", "ffprobe"))
+            : new Uri(Windows32FFMpegDownloadUrls[version].Replace("ffmpeg", "ffprobe"));
+        
+        HasValidUri(url);
+        
+        Stream zipStream = DownloadZip(url);
+
+        return ExtractAndSave(zipStream);
+    }
+    
+    public static List<string> AutoDownloadFFPlay(FFMpegVersions version = FFMpegVersions.V4_4_1)
+    {
+        var url = Environment.Is64BitProcess
+            ? new Uri(Windows64FFMpegDownloadUrls[version].Replace("ffmpeg", "ffplay"))
+            : new Uri(Windows32FFMpegDownloadUrls[version].Replace("ffmpeg", "ffplay"));
+        
+        HasValidUri(url);
+
+        Stream zipStream = DownloadZip(url);
+
         return ExtractAndSave(zipStream);
     }
 
-    private static MemoryStream DownloadFFMpeg(Uri address)
+    private static MemoryStream DownloadZip(Uri address)
     {
         var client = new WebClient();
         var zipStream = new MemoryStream(client.DownloadData(address));
@@ -51,14 +120,12 @@ public class FFMpegDownloader // this class is built to be easily modified to su
 
         return files;
     }
-    
-    private static string GetOSPlatform()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return "windows";
-        }
 
-        throw new PlatformNotSupportedException("Auto download is only supported on Windows.");
+    private static void HasValidUri(Uri uri)
+    {
+        if (uri.ToString() == "https://example.com/" || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            throw new PlatformNotSupportedException("The requested version of FFMpeg component is not available for your OS.");
+        }
     }
 }


### PR DESCRIPTION
## Runtime Auto Installation
You can install a version of ffmpeg suite at runtime using `FFMpegDownloader.DownloadFFMpegSuite();`

Or you can download only the desired binary using `FFMpegDownloader.DownloadFFMpeg()`, `FFMpegDownloader.DownloadFFProbe()`, `FFMpegDownloader.DownloadFFPlay()`.

| OS      |                      Support                      |
|---------|:-------------------------------------------------:|
| Windows |   x64 Fully Supported, x86 Up to version V4.2.1   |
| Mac OSX |                      NOT YET                      |
| Linux   |                      NOT YET                      |
