### PR TITLE
Fix issue where ffmpeg can't be found if x64/x86 folders exist withithout ffmpeg in there

### DIFF
--- a/FFMpegCore/GlobalFFOptions.cs
+++ b/FFMpegCore/GlobalFFOptions.cs
@@ -30,12 +30,23 @@ namespace FFMpegCore
             }
 
             var target = Environment.Is64BitProcess ? "x64" : "x86";
-            if (Directory.Exists(Path.Combine(ffOptions.BinaryFolder, target)))
+            var possiblePaths = new List<string>()
             {
-                ffName = Path.Combine(target, ffName);
+                Path.Combine(ffOptions.BinaryFolder, target),
+                ffOptions.BinaryFolder
+            };
+
+            foreach (var possiblePath in possiblePaths)
+            {
+                var possibleFFMpegPath = Path.Combine(possiblePath, ffName);
+                if (File.Exists(possibleFFMpegPath))
+                {
+                    return possibleFFMpegPath;
+                }
             }
 
-            return Path.Combine(ffOptions.BinaryFolder, ffName);
+            //Fall back to the assumption this tool exists in the PATH
+            return ffName;
         }
 
         private static FFOptions LoadFFOptions()


### PR DESCRIPTION
I ran into an issue where due to another program I was using my compilation created the x64 and x86 folders without ffmpeg being in there. Currently FFMpegCore doesn't fall back to using the "PATH" location to find FFMpeg if these folders are found.

I've changed the logic to actually check if FFMpeg is in these folders, if not, it will fall back to the normal approach of finding ffmpeg. Either in the current folder or simply in the PATH.

Would you be able to merge this PR and release a new NuGet package?