### PR TITLE
Update SaveM3U8Stream method to use "-codec copy" argument

### DIFF
--- a/FFMpegCore/FFMpeg/Arguments/CopyCodecArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/CopyCodecArgument.cs
@@ -1,0 +1,10 @@
+﻿namespace FFMpegCore.Arguments
+{
+    /// <summary>
+    /// Represents a copy codec parameter
+    /// </summary>
+    public class CopyCodecArgument : IArgument
+    {
+        public string Text => $"-codec copy";
+    }
+}

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -333,7 +333,10 @@ namespace FFMpegCore
             }
 
             return FFMpegArguments
-                .FromUrlInput(uri)
+                .FromUrlInput(uri, options =>
+                {
+                    options.WithCopyCodec();
+                })
                 .OutputToFile(output)
                 .ProcessSynchronously();
         }

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -77,6 +77,7 @@ namespace FFMpegCore
         public FFMpegArgumentOptions WithAudibleActivationBytes(string activationBytes) => WithArgument(new AudibleEncryptionKeyArgument(activationBytes));
         public FFMpegArgumentOptions WithTagVersion(int id3v2Version = 3) => WithArgument(new ID3V2VersionArgument(id3v2Version));
         public FFMpegArgumentOptions WithGifPaletteArgument(int streamIndex, Size? size, int fps = 12) => WithArgument(new GifPaletteArgument(streamIndex, fps, size));
+        public FFMpegArgumentOptions WithCopyCodec() => WithArgument(new CopyCodecArgument());
 
         public FFMpegArgumentOptions WithArgument(IArgument argument)
         {


### PR DESCRIPTION
By using `-codec copy` we save time and resources since FFmpeg doesn't need to perform the computationally intensive task of re-encoding the streams.

The improvements on download times are very noticeable with this option.