### PR TITLE
Add support for multiple outputs and tee muxer.

### DIFF
--- a/FFMpegCore/FFMpeg/Arguments/OutputTeeArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/OutputTeeArgument.cs
@@ -1,0 +1,57 @@
+﻿
+namespace FFMpegCore.Arguments
+{
+    internal class OutputTeeArgument : IOutputArgument
+    {
+        private readonly FFMpegMultiOutputOptions _options;
+
+        public OutputTeeArgument(FFMpegMultiOutputOptions options)
+        {
+            if (options.Outputs.Count == 0)
+            {
+                throw new ArgumentException("Atleast one output must be specified.", nameof(options));
+            }
+
+            _options = options;
+        }
+
+        public string Text => $"-f tee \"{string.Join("|", _options.Outputs.Select(MapOptions))}\"";
+
+        public Task During(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void Post()
+        {
+        }
+
+        public void Pre()
+        {
+        }
+
+        private static string MapOptions(FFMpegArgumentOptions option)
+        {
+            var optionPrefix = string.Empty;
+            if (option.Arguments.Count > 1)
+            {
+                var options = option.Arguments.Take(option.Arguments.Count - 1);
+                optionPrefix = $"[{string.Join(":", options.Select(MapArgument))}]";
+            }
+
+            var output = option.Arguments.OfType<IOutputArgument>().Single();
+            return $"{optionPrefix}{output.Text.Trim('"')}";
+        }
+
+        private static string MapArgument(IArgument argument)
+        {
+            if (argument is MapStreamArgument map)
+            {
+                return map.Text.Replace("-map ", "select=\\'") + "\\'";
+            }
+            else if (argument is BitStreamFilterArgument bitstreamFilter)
+            {
+                return bitstreamFilter.Text.Replace("-bsf:", "bsfs/").Replace(' ', '=');
+            }
+
+            return argument.Text.TrimStart('-').Replace(' ', '=');
+        }
+    }
+}

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -71,6 +71,21 @@ namespace FFMpegCore
             return new FFMpegArgumentProcessor(this);
         }
 
+        public FFMpegArgumentProcessor OutputToTee(Action<FFMpegMultiOutputOptions> addOutputs, Action<FFMpegArgumentOptions>? addArguments = null)
+        {
+            var outputs = new FFMpegMultiOutputOptions();
+            addOutputs(outputs);
+            return ToProcessor(new OutputTeeArgument(outputs), addArguments);
+        }
+
+        public FFMpegArgumentProcessor MultiOutput(Action<FFMpegMultiOutputOptions> addOutputs)
+        {
+            var args = new FFMpegMultiOutputOptions();
+            addOutputs(args);
+            Arguments.AddRange(args.Arguments);
+            return new FFMpegArgumentProcessor(this);
+        }
+
         internal void Pre()
         {
             foreach (var argument in Arguments.OfType<IInputOutputArgument>())

--- a/FFMpegCore/FFMpeg/FFMpegMultiOutputOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegMultiOutputOptions.cs
@@ -1,0 +1,29 @@
+﻿using FFMpegCore.Arguments;
+using FFMpegCore.Pipes;
+
+namespace FFMpegCore
+{
+    public class FFMpegMultiOutputOptions
+    {
+        internal readonly List<FFMpegArgumentOptions> Outputs = new();
+
+        public IEnumerable<IArgument> Arguments => Outputs.SelectMany(o => o.Arguments);
+
+        public FFMpegMultiOutputOptions OutputToFile(string file, bool overwrite = true, Action<FFMpegArgumentOptions>? addArguments = null) => AddOutput(new OutputArgument(file, overwrite), addArguments);
+
+        public FFMpegMultiOutputOptions OutputToUrl(string uri, Action<FFMpegArgumentOptions>? addArguments = null) => AddOutput(new OutputUrlArgument(uri), addArguments);
+
+        public FFMpegMultiOutputOptions OutputToUrl(Uri uri, Action<FFMpegArgumentOptions>? addArguments = null) => AddOutput(new OutputUrlArgument(uri.ToString()), addArguments);
+
+        public FFMpegMultiOutputOptions OutputToPipe(IPipeSink reader, Action<FFMpegArgumentOptions>? addArguments = null) => AddOutput(new OutputPipeArgument(reader), addArguments);
+
+        public FFMpegMultiOutputOptions AddOutput(IOutputArgument argument, Action<FFMpegArgumentOptions>? addArguments)
+        {
+            var args = new FFMpegArgumentOptions();
+            addArguments?.Invoke(args);
+            args.Arguments.Add(argument);
+            Outputs.Add(args);
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
A single input can be encoded simultaneously to multiple outputs or muxed in multiple formats in the same process
Fixes #377 