### PR TITLE
CancellableThrough() throws if token is already cancelled

### DIFF
--- a/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
+++ b/FFMpegCore.Test/FFMpegArgumentProcessorTest.cs
@@ -99,5 +99,13 @@ namespace FFMpegCore.Test
             var arg = new AudibleEncryptionKeyArgument("62689101");
             arg.Text.Should().Be($"-activation_bytes 62689101");
         }
+
+        [TestMethod]
+        public void Should_Throw_If_Token_Is_Cancelled()
+        {
+            var token = new CancellationToken(true);
+            var action = () => CreateArgumentProcessor().CancellableThrough(token);
+            action.Should().Throw<OperationCanceledException>();
+        }
     }
 }

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -73,6 +73,7 @@ namespace FFMpegCore
         }
         public FFMpegArgumentProcessor CancellableThrough(CancellationToken token, int timeout = 0)
         {
+            token.ThrowIfCancellationRequested();
             token.Register(() => CancelEvent?.Invoke(this, timeout));
             return this;
         }


### PR DESCRIPTION
I've added the solution marked with 1.  discussed in https://github.com/rosenbjerg/FFMpegCore/issues/468.

However, I think this doesn't solve the situation when cancellation is requested between calls to `CancellableThrough()` and `ProcessAsynchronously()` - I'd have to store the cancellation state somehow in the Argument Processor (maybe using a simple flag?). Please let me know what's the preferred solution.