### PR TITLE
Added a support for pre-exsiting pipe

### DIFF
--- a/FFMpegCore/FFMpeg/Arguments/InputExistingPipeArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/InputExistingPipeArgument.cs
@@ -1,0 +1,46 @@
+﻿using System.Diagnostics;
+using FFMpegCore.Pipes;
+
+namespace FFMpegCore.Arguments
+{
+    /// <summary>
+    /// Represents input parameter for a specific name pipe
+    /// </summary>
+    public class InputExistingPipeArgument : IInputArgument
+    {
+        public string PipeName { get; }
+        public string PipePath => PipeHelpers.GetPipePath(PipeName);
+        public string Text => $"-i \"{PipePath}\"";
+
+        public InputExistingPipeArgument(string pipeName)
+        {
+            PipeName = pipeName;
+        }
+
+        public void Pre()
+        {
+            if (string.IsNullOrEmpty(PipeName))
+            {
+                throw new InvalidOperationException("Pipe name cannot be null or empty");
+            }
+        }
+
+        public async Task During(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                cancellationToken.Register(() => tcs.TrySetCanceled());
+                await tcs.Task;
+            }
+            catch(OperationCanceledException)
+            {
+                Debug.WriteLine($"{GetType().Name} cancelled");
+            }
+        }
+
+        public void Post()
+        {
+        }
+    }
+}

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -25,6 +25,7 @@ namespace FFMpegCore
         public static FFMpegArguments FromUrlInput(Uri uri, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputArgument(uri.AbsoluteUri, false), addArguments);
         public static FFMpegArguments FromDeviceInput(string device, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputDeviceArgument(device), addArguments);
         public static FFMpegArguments FromPipeInput(IPipeSource sourcePipe, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputPipeArgument(sourcePipe), addArguments);
+        public static FFMpegArguments FromPipeInput(string pipeName, Action<FFMpegArgumentOptions>? addArguments = null) => new FFMpegArguments().WithInput(new InputExistingPipeArgument(pipeName), addArguments);
 
         public FFMpegArguments WithGlobalOptions(Action<FFMpegGlobalArguments> configureOptions)
         {
@@ -39,6 +40,7 @@ namespace FFMpegCore
         public FFMpegArguments AddUrlInput(Uri uri, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new InputArgument(uri.AbsoluteUri, false), addArguments);
         public FFMpegArguments AddDeviceInput(string device, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new InputDeviceArgument(device), addArguments);
         public FFMpegArguments AddPipeInput(IPipeSource sourcePipe, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new InputPipeArgument(sourcePipe), addArguments);
+        public FFMpegArguments AddPipeInput(string pipeName, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new InputExistingPipeArgument(pipeName), addArguments);
         public FFMpegArguments AddMetaData(string content, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new MetaDataArgument(content), addArguments);
         public FFMpegArguments AddMetaData(IReadOnlyMetaData metaData, Action<FFMpegArgumentOptions>? addArguments = null) => WithInput(new MetaDataArgument(MetaDataSerializer.Instance.Serialize(metaData)), addArguments);
 

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Description>A .NET Standard FFMpeg/FFProbe wrapper for easily integrating media analysis and conversion into your .NET applications</Description>
-    <PackageVersion>5.1.0</PackageVersion>
+    <PackageVersion>5.1.1</PackageVersion>
     <PackageOutputPath>../nupkg</PackageOutputPath>
     <PackageReleaseNotes>
     </PackageReleaseNotes>


### PR DESCRIPTION
Sometimes you don't want a "Middle-man" pipe and want to use a pre-existing pipe.
This is super important if you want to avoid copying the objects that pass through the stream and might weight more than a few MBs.