### PR TITLE
Fix fps handling in JoinImageSequence

### DIFF
--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -739,7 +739,7 @@ public class VideoTest
         Assert.IsTrue(success);
         var result = FFProbe.Analyse(outputFile);
 
-        Assert.AreEqual(1, result.Duration.Seconds);
+        Assert.AreEqual(3, result.Duration.Seconds);
         Assert.AreEqual(imageAnalysis.PrimaryVideoStream!.Width, result.PrimaryVideoStream!.Width);
         Assert.AreEqual(imageAnalysis.PrimaryVideoStream!.Height, result.PrimaryVideoStream.Height);
     }

--- a/FFMpegCore/FFMpeg/Arguments/GifPaletteArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/GifPaletteArgument.cs
@@ -4,12 +4,11 @@ namespace FFMpegCore.Arguments;
 
 public class GifPaletteArgument : IArgument
 {
-    private readonly int _fps;
-
+    private readonly double _fps;
     private readonly Size? _size;
     private readonly int _streamIndex;
 
-    public GifPaletteArgument(int streamIndex, int fps, Size? size)
+    public GifPaletteArgument(int streamIndex, double fps, Size? size)
     {
         _streamIndex = streamIndex;
         _fps = fps;

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -132,7 +132,8 @@ public static class FFMpeg
             }
 
             return FFMpegArguments
-                .FromFileInput(Path.Combine(tempFolderName, $"%09d{fileExtension}"), false)
+                .FromFileInput(Path.Combine(tempFolderName, $"%09d{fileExtension}"), false, options => options
+                    .WithFramerate(frameRate))
                 .OutputToFile(output, true, options => options
                     .ForcePixelFormat("yuv420p")
                     .Resize(width!.Value, height!.Value)

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -258,7 +258,7 @@ public class FFMpegArgumentOptions : FFMpegArgumentsBase
         return WithArgument(new ID3V2VersionArgument(id3v2Version));
     }
 
-    public FFMpegArgumentOptions WithGifPaletteArgument(int streamIndex, Size? size, int fps = 12)
+    public FFMpegArgumentOptions WithGifPaletteArgument(int streamIndex, Size? size, double fps = 12)
     {
         return WithArgument(new GifPaletteArgument(streamIndex, fps, size));
     }

--- a/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
+++ b/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
@@ -62,7 +62,7 @@ public static class SnapshotArgumentBuilder
         TimeSpan? captureTime = null,
         TimeSpan? duration = null,
         int? streamIndex = null,
-        int fps = 12)
+        double fps = 12)
     {
         var defaultGifOutputSize = new Size(480, -1);
 


### PR DESCRIPTION
Change fps argument to double in GifPaletteArgument
#564 #567 