### PR TITLE
Support send and received analysis data over I/O stream

### DIFF
--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -11,7 +11,7 @@ public class FFProbeAnalysis
 
     [JsonPropertyName("chapters")] public List<Chapter> Chapters { get; set; } = null!;
 
-    [JsonIgnore] public IReadOnlyList<string> ErrorData { get; set; } = new List<string>();
+    public IReadOnlyList<string> ErrorData { get; set; } = new List<string>();
 }
 
 public class FFProbeStream : ITagsContainer, IDispositionContainer

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -4,9 +4,9 @@ using FFMpegCore.Builders.MetaData;
 
 namespace FFMpegCore;
 
-internal class MediaAnalysis : IMediaAnalysis
+public class MediaAnalysis : IMediaAnalysis
 {
-    internal MediaAnalysis(FFProbeAnalysis analysis)
+    public MediaAnalysis(FFProbeAnalysis analysis)
     {
         Format = ParseFormat(analysis.Format);
         Chapters = analysis.Chapters.Select(c => ParseChapter(c)).ToList();


### PR DESCRIPTION
issues #589 

- Make FFProbeAnalysis and ctor public
- Remove `[JsonIgnore]` https://github.com/rosenbjerg/FFMpegCore/blob/a599c48511cb9ba059b00e3c3a4276650388ec4b/FFMpegCore/FFProbe/FFProbeAnalysis.cs#L14  
- Add `FFProbe.GetAnalysis` and `FFProbe.GetAnalysisAsync`
  + `Analyse` and `AnalyseAsync` change to use `GetAnalysis` and `GetAnalysisAsync`  
  
```csharp
//Remote
var anl = await FFProbe.GetAnalysisAsync(filePath_or_stream);
response anl as json

//Client
string json = ...;
FFProbeAnalysis anl =  JsonSerializer.Deserialize<FFProbeAnalysis>(json);
return new MediaAnalysis(anl);
```
  