### PR TITLE
Add raw response from ffprobe in MediaAnalysis

### DIFF
--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -351,4 +351,13 @@ public class FFProbeTests
         await Assert.ThrowsAsync<FFMpegException>(async () => await FFProbe.AnalyseAsync(input,
             cancellationToken: TestContext.CancellationToken, customArguments: "--some-invalid-argument"));
     }
+
+    [TestMethod]
+    public void Probe_Success_Output_Data()
+    {
+        var info = FFProbe.Analyse(TestResources.Mp4Video);
+
+        Assert.AreNotEqual(0, info.OutputData.Count);
+        CollectionAssert.Contains(info.OutputData.ToList(), "            \"codec_long_name\": \"H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10\",");
+    }
 }

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -177,7 +177,9 @@ public static class FFProbe
             throw new FormatNullException();
         }
 
+        ffprobeAnalysis.OutputData = instance.OutputData;
         ffprobeAnalysis.ErrorData = instance.ErrorData;
+
         return new MediaAnalysis(ffprobeAnalysis);
     }
 

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -11,6 +11,8 @@ public class FFProbeAnalysis
 
     [JsonPropertyName("chapters")] public List<Chapter> Chapters { get; set; } = null!;
 
+    [JsonIgnore] public IReadOnlyList<string> OutputData { get; set; } = new List<string>();
+
     [JsonIgnore] public IReadOnlyList<string> ErrorData { get; set; } = new List<string>();
 }
 

--- a/FFMpegCore/FFProbe/IMediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/IMediaAnalysis.cs
@@ -13,5 +13,6 @@ public interface IMediaAnalysis
     List<VideoStream> VideoStreams { get; }
     List<AudioStream> AudioStreams { get; }
     List<SubtitleStream> SubtitleStreams { get; }
+    IReadOnlyList<string> OutputData { get; }
     IReadOnlyList<string> ErrorData { get; }
 }

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -9,10 +9,11 @@ internal class MediaAnalysis : IMediaAnalysis
     internal MediaAnalysis(FFProbeAnalysis analysis)
     {
         Format = ParseFormat(analysis.Format);
-        Chapters = analysis.Chapters.Select(c => ParseChapter(c)).ToList();
+        Chapters = analysis.Chapters.Select(ParseChapter).ToList();
         VideoStreams = analysis.Streams.Where(stream => stream.CodecType == "video").Select(ParseVideoStream).ToList();
         AudioStreams = analysis.Streams.Where(stream => stream.CodecType == "audio").Select(ParseAudioStream).ToList();
         SubtitleStreams = analysis.Streams.Where(stream => stream.CodecType == "subtitle").Select(ParseSubtitleStream).ToList();
+        OutputData = analysis.OutputData;
         ErrorData = analysis.ErrorData;
     }
 
@@ -29,6 +30,7 @@ internal class MediaAnalysis : IMediaAnalysis
     public List<VideoStream> VideoStreams { get; }
     public List<AudioStream> AudioStreams { get; }
     public List<SubtitleStream> SubtitleStreams { get; }
+    public IReadOnlyList<string> OutputData { get; }
     public IReadOnlyList<string> ErrorData { get; }
 
     private MediaFormat ParseFormat(Format analysisFormat)


### PR DESCRIPTION
Exposing the raw response from ffprobe in FFProbeAnalysis and MediaAnalysis, which would allow to be saved if needed as is without needing to remove `JsonIgnore` from `FFProbeAnalysis` since no serialization would be involved.