### PR TITLE
Add cancellation token support for the [Gif]SnapshotAsync 

### DIFF
--- a/FFMpegCore.Extensions.SkiaSharp/FFMpegImage.cs
+++ b/FFMpegCore.Extensions.SkiaSharp/FFMpegImage.cs
@@ -39,18 +39,21 @@ public static class FFMpegImage
     /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
     /// <param name="streamIndex">Selected video stream index.</param>
     /// <param name="inputFileIndex">Input file index</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Bitmap with the requested snapshot.</returns>
     public static async Task<SKBitmap> SnapshotAsync(string input, Size? size = null, TimeSpan? captureTime = null, int? streamIndex = null,
-        int inputFileIndex = 0)
+        int inputFileIndex = 0, CancellationToken cancellationToken = default)
     {
-        var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
+        var source = await FFProbe.AnalyseAsync(input, cancellationToken: cancellationToken).ConfigureAwait(false);
         var (arguments, outputOptions) = SnapshotArgumentBuilder.BuildSnapshotArguments(input, source, size, captureTime, streamIndex, inputFileIndex);
         using var ms = new MemoryStream();
 
         await arguments
             .OutputToPipe(new StreamPipeSink(ms), options => outputOptions(options
                 .ForceFormat("rawvideo")))
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
 
         ms.Position = 0;
         return SKBitmap.Decode(ms);

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -698,7 +698,8 @@ public class VideoTest
         using var outputPath = new TemporaryFile("out.gif");
         var input = FFProbe.Analyse(TestResources.Mp4Video);
 
-        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, captureTime: TimeSpan.FromSeconds(0));
+        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, captureTime: TimeSpan.FromSeconds(0),
+            cancellationToken: TestContext.CancellationToken);
 
         var analysis = FFProbe.Analyse(outputPath);
         Assert.AreNotEqual(input.PrimaryVideoStream!.Width, analysis.PrimaryVideoStream!.Width);
@@ -714,7 +715,8 @@ public class VideoTest
         var input = FFProbe.Analyse(TestResources.Mp4Video);
         var desiredGifSize = new Size(320, 240);
 
-        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, desiredGifSize, TimeSpan.FromSeconds(0));
+        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, desiredGifSize, TimeSpan.FromSeconds(0),
+            cancellationToken: TestContext.CancellationToken);
 
         var analysis = FFProbe.Analyse(outputPath);
         Assert.AreNotEqual(input.PrimaryVideoStream!.Width, desiredGifSize.Width);

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -37,16 +37,19 @@ public static class FFMpeg
     /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
     /// <param name="streamIndex">Selected video stream index.</param>
     /// <param name="inputFileIndex">Input file index</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Bitmap with the requested snapshot.</returns>
     public static async Task<bool> SnapshotAsync(string input, string output, Size? size = null, TimeSpan? captureTime = null, int? streamIndex = null,
-        int inputFileIndex = 0)
+        int inputFileIndex = 0, CancellationToken cancellationToken = default)
     {
         CheckSnapshotOutputExtension(output, FileExtension.Image.All);
 
-        var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
+        var source = await FFProbe.AnalyseAsync(input, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return await SnapshotProcess(input, output, source, size, captureTime, streamIndex, inputFileIndex)
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
     }
 
     public static bool GifSnapshot(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null,
@@ -61,14 +64,16 @@ public static class FFMpeg
     }
 
     public static async Task<bool> GifSnapshotAsync(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null,
-        int? streamIndex = null)
+        int? streamIndex = null, CancellationToken cancellationToken = default)
     {
         CheckSnapshotOutputExtension(output, [FileExtension.Gif]);
 
-        var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
+        var source = await FFProbe.AnalyseAsync(input, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return await GifSnapshotProcess(input, output, source, size, captureTime, duration, streamIndex)
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
     }
 
     private static FFMpegArgumentProcessor SnapshotProcess(string input, string output, IMediaAnalysis source, Size? size = null, TimeSpan? captureTime = null,
@@ -321,11 +326,15 @@ public static class FFMpeg
     /// <param name="output">Output video file.</param>
     /// <param name="startTime">The start time of when the sub video needs to start</param>
     /// <param name="endTime">The end time of where the sub video needs to  end</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Output video information.</returns>
-    public static async Task<bool> SubVideoAsync(string input, string output, TimeSpan startTime, TimeSpan endTime)
+    public static async Task<bool> SubVideoAsync(string input, string output, TimeSpan startTime, TimeSpan endTime,
+        CancellationToken cancellationToken = default)
     {
         return await BaseSubVideo(input, output, startTime, endTime)
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -166,12 +166,28 @@ public class FFMpegArgumentProcessor
 
         void OnCancelEvent(object sender, int timeout)
         {
-            instance.SendInput("q");
+            ExecuteIgnoringFinishedProcessExceptions(() => instance.SendInput("q"));
 
             if (!cancellationTokenSource.Token.WaitHandle.WaitOne(timeout, true))
             {
                 cancellationTokenSource.Cancel();
-                instance.Kill();
+                ExecuteIgnoringFinishedProcessExceptions(() => instance.Kill());
+            }
+
+            static void ExecuteIgnoringFinishedProcessExceptions(Action action)
+            {
+                try
+                {
+                    action();
+                }
+                catch (Instances.Exceptions.InstanceProcessAlreadyExitedException)
+                {
+                    //ignore
+                }
+                catch (ObjectDisposedException)
+                {
+                    //ignore
+                }
             }
         }
 


### PR DESCRIPTION
### Description
This pull request addresses the following:
- Adds cancellation support to `SnapshotAsync`, `GifSnapshotAsync`, and `SubVideoAsync` methods. Fixes #592.

- Fixes a race condition during cancellation of an asynchronous operation when the FFmpeg process had already exited. Fixes #348. 
