### PR TITLE
Do not throw unexpected FFMpegException on FFProbe cancallation. Fixes  #594

### DIFF
--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -285,4 +285,61 @@ public class FFProbeTests
         var info = FFProbe.Analyse(TestResources.Mp4Video, customArguments: "-headers \"Hello: World\"");
         Assert.AreEqual(3, info.Duration.Seconds);
     }
+
+    [TestMethod]
+    [Timeout(10000, CooperativeCancellation = true)]
+    public async Task Parallel_FFProbe_Cancellation_Should_Throw_Only_OperationCanceledException()
+    {
+        // Warm up FFMpegCore environment
+        Helpers.FFProbeHelper.VerifyFFProbeExists(GlobalFFOptions.Current);
+
+        var mp4 = TestResources.Mp4Video;
+        if (!File.Exists(mp4))
+        {
+            Assert.Inconclusive($"Test video not found: {mp4}");
+            return;
+        }
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        var token = cts.Token;
+        using var semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+        var tasks = Enumerable.Range(0, 50).Select(x => Task.Run(async () =>
+        {
+            await semaphore.WaitAsync(token);
+            try
+            {
+                var analysis = await FFProbe.AnalyseAsync(mp4, cancellationToken: token);
+                return analysis;
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }, token)).ToList();
+
+        // Wait for 2 tasks to finish, then cancel all
+        await Task.WhenAny(tasks);
+        await Task.WhenAny(tasks);
+        await cts.CancelAsync();
+        cts.Dispose();
+
+        var exceptions = new List<Exception>();
+        foreach (var task in tasks)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+        }
+
+        Assert.IsNotEmpty(exceptions, "No exceptions were thrown on cancellation. Test was useless. " +
+                                      ".Try adjust cancellation timings to make cancellation at the moment, when ffprobe is still running.");
+
+        // Check that all exceptions are OperationCanceledException
+        CollectionAssert.AllItemsAreInstancesOfType(exceptions, typeof(OperationCanceledException));
+    }
 }

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -1,4 +1,5 @@
-﻿using FFMpegCore.Test.Resources;
+﻿using FFMpegCore.Exceptions;
+using FFMpegCore.Test.Resources;
 
 namespace FFMpegCore.Test;
 
@@ -341,5 +342,14 @@ public class FFProbeTests
 
         // Check that all exceptions are OperationCanceledException
         CollectionAssert.AllItemsAreInstancesOfType(exceptions, typeof(OperationCanceledException));
+    }
+
+    [TestMethod]
+    [Timeout(10000, CooperativeCancellation = true)]
+    public async Task FFProbe_Should_Throw_FFMpegException_When_Exits_With_Non_Zero_Code()
+    {
+        var input = TestResources.SrtSubtitle; //non media file
+        await Assert.ThrowsAsync<FFMpegException>(async () => await FFProbe.AnalyseAsync(input,
+            cancellationToken: TestContext.CancellationToken, customArguments: "--some-invalid-argument"));
     }
 }

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -214,11 +214,11 @@ public static class FFProbe
 
     private static void ThrowIfExitCodeNotZero(IProcessResult result, CancellationToken cancellationToken = default)
     {
-        // if cancellation requested, then we are not interested in the exit code, just throw the cancellation exception
-        // to get consistent and expected behavior.
-        cancellationToken.ThrowIfCancellationRequested();
         if (result.ExitCode != 0)
         {
+            // if cancellation requested, then we are not interested in the exit code, just throw the cancellation exception
+            // to get consistent and expected behavior.
+            cancellationToken.ThrowIfCancellationRequested();
             var message = $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})";
             throw new FFMpegException(FFMpegExceptionType.Process, message, null, string.Join("\n", result.ErrorData));
         }

--- a/FFMpegCore/FFProbe/ProcessArgumentsExtensions.cs
+++ b/FFMpegCore/FFProbe/ProcessArgumentsExtensions.cs
@@ -13,6 +13,6 @@ public static class ProcessArgumentsExtensions
     public static async Task<IProcessResult> StartAndWaitForExitAsync(this ProcessArguments processArguments, CancellationToken cancellationToken = default)
     {
         using var instance = processArguments.Start();
-        return await instance.WaitForExitAsync(cancellationToken);
+        return await instance.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
FFProbe helper will now throw an `OperationCancelledException` if a cancellation was requested, rather than an `FFMpegException`, even if the ffprobe exited with a non-zero exit code. This is reasonable behavior as the any results are usesless after the cancellation and any exceptions except for an `OperationCancelledException` and similar are unexpected.

A test was added to verify the initial problem and the fix.

Fixes  #594