### PR TITLE
V.5.4.0

### DIFF
--- a/FFMpegCore.Extensions.SkiaSharp/FFMpegImage.cs
+++ b/FFMpegCore.Extensions.SkiaSharp/FFMpegImage.cs
@@ -39,18 +39,21 @@ public static class FFMpegImage
     /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
     /// <param name="streamIndex">Selected video stream index.</param>
     /// <param name="inputFileIndex">Input file index</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Bitmap with the requested snapshot.</returns>
     public static async Task<SKBitmap> SnapshotAsync(string input, Size? size = null, TimeSpan? captureTime = null, int? streamIndex = null,
-        int inputFileIndex = 0)
+        int inputFileIndex = 0, CancellationToken cancellationToken = default)
     {
-        var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
+        var source = await FFProbe.AnalyseAsync(input, cancellationToken: cancellationToken).ConfigureAwait(false);
         var (arguments, outputOptions) = SnapshotArgumentBuilder.BuildSnapshotArguments(input, source, size, captureTime, streamIndex, inputFileIndex);
         using var ms = new MemoryStream();
 
         await arguments
             .OutputToPipe(new StreamPipeSink(ms), options => outputOptions(options
                 .ForceFormat("rawvideo")))
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
 
         ms.Position = 0;
         return SKBitmap.Decode(ms);

--- a/FFMpegCore.Test/AudioTest.cs
+++ b/FFMpegCore.Test/AudioTest.cs
@@ -9,6 +9,8 @@ namespace FFMpegCore.Test;
 [TestClass]
 public class AudioTest
 {
+    public TestContext TestContext { get; set; }
+
     [TestMethod]
     public void Audio_Remove()
     {
@@ -41,6 +43,7 @@ public class AudioTest
         await FFMpegArguments
             .FromPipeInput(new StreamPipeSource(file), options => options.ForceFormat("s16le"))
             .OutputToPipe(new StreamPipeSink(memoryStream), options => options.ForceFormat("mp3"))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously();
     }
 
@@ -83,6 +86,7 @@ public class AudioTest
             .FromPipeInput(audioSamplesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithAudioCodec(AudioCodec.Aac))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -101,6 +105,7 @@ public class AudioTest
             .FromPipeInput(audioSamplesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithAudioCodec(AudioCodec.LibVorbis))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -119,6 +124,7 @@ public class AudioTest
             .FromPipeInput(audioSamplesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithAudioCodec(AudioCodec.Aac))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously();
         Assert.IsTrue(success);
     }
@@ -137,6 +143,7 @@ public class AudioTest
             .FromPipeInput(audioSamplesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithAudioCodec(AudioCodec.Aac))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -153,6 +160,7 @@ public class AudioTest
             .FromPipeInput(audioSamplesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithAudioCodec(AudioCodec.Aac))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously());
     }
 
@@ -168,6 +176,7 @@ public class AudioTest
             .FromPipeInput(audioSamplesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithAudioCodec(AudioCodec.Aac))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously());
     }
 
@@ -183,6 +192,7 @@ public class AudioTest
             .FromPipeInput(audioSamplesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithAudioCodec(AudioCodec.Aac))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously());
     }
 
@@ -196,6 +206,7 @@ public class AudioTest
             .OutputToFile(outputFile, true,
                 argumentOptions => argumentOptions
                     .WithAudioFilters(filter => filter.Pan(1, "c0 < 0.9 * c0 + 0.1 * c1")))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         var mediaAnalysis = FFProbe.Analyse(outputFile);
@@ -215,6 +226,7 @@ public class AudioTest
             .OutputToFile(outputFile, true,
                 argumentOptions => argumentOptions
                     .WithAudioFilters(filter => filter.Pan(1)))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         var mediaAnalysis = FFProbe.Analyse(outputFile);
@@ -234,6 +246,7 @@ public class AudioTest
             .OutputToFile(outputFile, true,
                 argumentOptions => argumentOptions
                     .WithAudioFilters(filter => filter.Pan(1, "c0=c0", "c1=c1")))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously());
     }
 
@@ -247,6 +260,7 @@ public class AudioTest
             .OutputToFile(outputFile, true,
                 argumentOptions => argumentOptions
                     .WithAudioFilters(filter => filter.Pan("mono", "c0=c0", "c1=c1")))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously());
     }
 
@@ -260,6 +274,7 @@ public class AudioTest
             .OutputToFile(outputFile, true,
                 argumentOptions => argumentOptions
                     .WithAudioFilters(filter => filter.DynamicNormalizer()))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         Assert.IsTrue(success);
@@ -275,6 +290,7 @@ public class AudioTest
             .OutputToFile(outputFile, true,
                 argumentOptions => argumentOptions
                     .WithAudioFilters(filter => filter.DynamicNormalizer(250, 7, 0.9, 2, 1, false, true, true, 0.5)))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         Assert.IsTrue(success);
@@ -294,6 +310,7 @@ public class AudioTest
             .OutputToFile(outputFile, true,
                 argumentOptions => argumentOptions
                     .WithAudioFilters(filter => filter.DynamicNormalizer(filterWindow: filterWindow)))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously());
     }
 }

--- a/FFMpegCore.Test/AudioTest.cs
+++ b/FFMpegCore.Test/AudioTest.cs
@@ -9,7 +9,7 @@ namespace FFMpegCore.Test;
 [TestClass]
 public class AudioTest
 {
-    private const int BaseTimeoutMilliseconds = 15_000;
+    private const int BaseTimeoutMilliseconds = 30_000;
 
     public TestContext TestContext { get; set; }
 

--- a/FFMpegCore.Test/AudioTest.cs
+++ b/FFMpegCore.Test/AudioTest.cs
@@ -9,6 +9,8 @@ namespace FFMpegCore.Test;
 [TestClass]
 public class AudioTest
 {
+    private const int BaseTimeoutMilliseconds = 15_000;
+
     public TestContext TestContext { get; set; }
 
     [TestMethod]
@@ -73,7 +75,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_ToAAC_Args_Pipe()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -92,7 +94,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_ToLibVorbis_Args_Pipe()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -111,7 +113,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task Audio_ToAAC_Args_Pipe_Async()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -130,7 +132,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_ToAAC_Args_Pipe_ValidDefaultConfiguration()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -149,7 +151,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_ToAAC_Args_Pipe_InvalidChannels()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -165,7 +167,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_ToAAC_Args_Pipe_InvalidFormat()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -181,7 +183,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_ToAAC_Args_Pipe_InvalidSampleRate()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -197,7 +199,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_Pan_ToMono()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -217,7 +219,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_Pan_ToMonoNoDefinitions()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -237,7 +239,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_Pan_ToMonoChannelsToOutputDefinitionsMismatch()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -251,7 +253,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_Pan_ToMonoChannelsLayoutToOutputDefinitionsMismatch()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -265,7 +267,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_DynamicNormalizer_WithDefaultValues()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -281,7 +283,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Audio_DynamicNormalizer_WithNonDefaultValues()
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
@@ -297,7 +299,7 @@ public class AudioTest
     }
 
     [TestMethod]
-    [Timeout(10000, CooperativeCancellation = true)]
+    [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     [DataRow(2)]
     [DataRow(32)]
     [DataRow(8)]

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -285,4 +285,61 @@ public class FFProbeTests
         var info = FFProbe.Analyse(TestResources.Mp4Video, customArguments: "-headers \"Hello: World\"");
         Assert.AreEqual(3, info.Duration.Seconds);
     }
+
+    [TestMethod]
+    [Timeout(10000, CooperativeCancellation = true)]
+    public async Task Parallel_FFProbe_Cancellation_Should_Throw_Only_OperationCanceledException()
+    {
+        // Warm up FFMpegCore environment
+        Helpers.FFProbeHelper.VerifyFFProbeExists(GlobalFFOptions.Current);
+
+        var mp4 = TestResources.Mp4Video;
+        if (!File.Exists(mp4))
+        {
+            Assert.Inconclusive($"Test video not found: {mp4}");
+            return;
+        }
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        var token = cts.Token;
+        using var semaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+        var tasks = Enumerable.Range(0, 50).Select(x => Task.Run(async () =>
+        {
+            await semaphore.WaitAsync(token);
+            try
+            {
+                var analysis = await FFProbe.AnalyseAsync(mp4, cancellationToken: token);
+                return analysis;
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }, token)).ToList();
+
+        // Wait for 2 tasks to finish, then cancel all
+        await Task.WhenAny(tasks);
+        await Task.WhenAny(tasks);
+        await cts.CancelAsync();
+        cts.Dispose();
+
+        var exceptions = new List<Exception>();
+        foreach (var task in tasks)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+        }
+
+        Assert.IsNotEmpty(exceptions, "No exceptions were thrown on cancellation. Test was useless. " +
+                                      ".Try adjust cancellation timings to make cancellation at the moment, when ffprobe is still running.");
+
+        // Check that all exceptions are OperationCanceledException
+        CollectionAssert.AllItemsAreInstancesOfType(exceptions, typeof(OperationCanceledException));
+    }
 }

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -1,4 +1,5 @@
-﻿using FFMpegCore.Test.Resources;
+﻿using FFMpegCore.Exceptions;
+using FFMpegCore.Test.Resources;
 
 namespace FFMpegCore.Test;
 
@@ -341,5 +342,14 @@ public class FFProbeTests
 
         // Check that all exceptions are OperationCanceledException
         CollectionAssert.AllItemsAreInstancesOfType(exceptions, typeof(OperationCanceledException));
+    }
+
+    [TestMethod]
+    [Timeout(10000, CooperativeCancellation = true)]
+    public async Task FFProbe_Should_Throw_FFMpegException_When_Exits_With_Non_Zero_Code()
+    {
+        var input = TestResources.SrtSubtitle; //non media file
+        await Assert.ThrowsAsync<FFMpegException>(async () => await FFProbe.AnalyseAsync(input,
+            cancellationToken: TestContext.CancellationToken, customArguments: "--some-invalid-argument"));
     }
 }

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -17,7 +17,7 @@ namespace FFMpegCore.Test;
 [TestClass]
 public class VideoTest
 {
-    private const int BaseTimeoutMilliseconds = 30_000;
+    private const int BaseTimeoutMilliseconds = 60_000;
 
     public TestContext TestContext { get; set; }
 

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -17,7 +17,7 @@ namespace FFMpegCore.Test;
 [TestClass]
 public class VideoTest
 {
-    private const int BaseTimeoutMilliseconds = 15_000;
+    private const int BaseTimeoutMilliseconds = 30_000;
 
     public TestContext TestContext { get; set; }
 

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -217,7 +217,6 @@ public class VideoTest
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
-
         var frames = new List<IVideoFrame>
         {
             BitmapSource.CreateVideoFrame(0, pixelFormatFrame1, 255, 255, 1, 0), BitmapSource.CreateVideoFrame(0, pixelFormatFrame2, 255, 255, 1, 0)

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -698,7 +698,8 @@ public class VideoTest
         using var outputPath = new TemporaryFile("out.gif");
         var input = FFProbe.Analyse(TestResources.Mp4Video);
 
-        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, captureTime: TimeSpan.FromSeconds(0));
+        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, captureTime: TimeSpan.FromSeconds(0),
+            cancellationToken: TestContext.CancellationToken);
 
         var analysis = FFProbe.Analyse(outputPath);
         Assert.AreNotEqual(input.PrimaryVideoStream!.Width, analysis.PrimaryVideoStream!.Width);
@@ -714,7 +715,8 @@ public class VideoTest
         var input = FFProbe.Analyse(TestResources.Mp4Video);
         var desiredGifSize = new Size(320, 240);
 
-        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, desiredGifSize, TimeSpan.FromSeconds(0));
+        await FFMpeg.GifSnapshotAsync(TestResources.Mp4Video, outputPath, desiredGifSize, TimeSpan.FromSeconds(0),
+            cancellationToken: TestContext.CancellationToken);
 
         var analysis = FFProbe.Analyse(outputPath);
         Assert.AreNotEqual(input.PrimaryVideoStream!.Width, desiredGifSize.Width);

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -739,7 +739,7 @@ public class VideoTest
         Assert.IsTrue(success);
         var result = FFProbe.Analyse(outputFile);
 
-        Assert.AreEqual(1, result.Duration.Seconds);
+        Assert.AreEqual(3, result.Duration.Seconds);
         Assert.AreEqual(imageAnalysis.PrimaryVideoStream!.Width, result.PrimaryVideoStream!.Width);
         Assert.AreEqual(imageAnalysis.PrimaryVideoStream!.Height, result.PrimaryVideoStream.Height);
     }

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -1050,7 +1050,7 @@ public class VideoTest
     {
         using var outputFile = new TemporaryFile("out.mp4");
 
-        var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
 
         var task = FFMpegArguments
             .FromFileInput("testsrc2=size=320x240[out0]; sine[out1]", false, args => args
@@ -1061,7 +1061,6 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(cts.Token)
-            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously(false);
 
         cts.CancelAfter(300);
@@ -1077,7 +1076,7 @@ public class VideoTest
     {
         using var outputFile = new TemporaryFile("out.mp4");
 
-        var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
 
         var task = FFMpegArguments
             .FromFileInput("testsrc2=size=320x240[out0]; sine[out1]", false, args => args
@@ -1088,7 +1087,6 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(cts.Token)
-            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously();
 
         cts.CancelAfter(300);
@@ -1102,7 +1100,7 @@ public class VideoTest
     {
         using var outputFile = new TemporaryFile("out.mp4");
 
-        var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
 
         var task = FFMpegArguments
             .FromFileInput("testsrc2=size=320x240[out0]; sine[out1]", false, args => args
@@ -1126,7 +1124,7 @@ public class VideoTest
     {
         using var outputFile = new TemporaryFile("out.mp4");
 
-        var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
 
         cts.Cancel();
         var task = FFMpegArguments
@@ -1149,7 +1147,7 @@ public class VideoTest
     {
         using var outputFile = new TemporaryFile("out.mp4");
 
-        var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
 
         var task = FFMpegArguments
             .FromFileInput("testsrc2=size=320x240[out0]; sine[out1]", false, args => args

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -30,6 +30,7 @@ public class VideoTest
         var success = FFMpegArguments
             .FromFileInput(TestResources.WebmVideo)
             .OutputToFile(outputFile, false)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -43,6 +44,7 @@ public class VideoTest
         var success = FFMpegArguments
             .FromFileInput(TestResources.WebmVideo)
             .OutputToFile(outputFile, false)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -58,6 +60,7 @@ public class VideoTest
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264)
                 .ForcePixelFormat("yuv444p"))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
         var analysis = FFProbe.Analyse(outputFile);
@@ -74,6 +77,7 @@ public class VideoTest
             .FromFileInput(TestResources.WebmVideo)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -88,6 +92,7 @@ public class VideoTest
             .FromFileInput(TestResources.WebmVideo)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX265))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -99,7 +104,7 @@ public class VideoTest
     [DataRow(PixelFormat.Format32bppArgb)]
     public void Video_ToMP4_Args_Pipe_WindowsOnly(PixelFormat pixelFormat)
     {
-        Video_ToMP4_Args_Pipe_Internal(pixelFormat);
+        Video_ToMP4_Args_Pipe_Internal(pixelFormat, TestContext.CancellationToken);
     }
 
     [TestMethod]
@@ -108,10 +113,10 @@ public class VideoTest
     [DataRow(SKColorType.Bgra8888)]
     public void Video_ToMP4_Args_Pipe(SKColorType pixelFormat)
     {
-        Video_ToMP4_Args_Pipe_Internal(pixelFormat);
+        Video_ToMP4_Args_Pipe_Internal(pixelFormat, TestContext.CancellationToken);
     }
 
-    private static void Video_ToMP4_Args_Pipe_Internal(dynamic pixelFormat)
+    private static void Video_ToMP4_Args_Pipe_Internal(dynamic pixelFormat, CancellationToken cancellationToken)
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
@@ -120,6 +125,7 @@ public class VideoTest
             .FromPipeInput(videoFramesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(cancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -129,17 +135,17 @@ public class VideoTest
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Video_ToMP4_Args_Pipe_DifferentImageSizes_WindowsOnly()
     {
-        Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal(PixelFormat.Format24bppRgb);
+        Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal(PixelFormat.Format24bppRgb, TestContext.CancellationToken);
     }
 
     [TestMethod]
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Video_ToMP4_Args_Pipe_DifferentImageSizes()
     {
-        Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal(SKColorType.Rgb565);
+        Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal(SKColorType.Rgb565, TestContext.CancellationToken);
     }
 
-    private static void Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal(dynamic pixelFormat)
+    private static void Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal(dynamic pixelFormat, CancellationToken cancellationToken)
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
@@ -153,6 +159,7 @@ public class VideoTest
             .FromPipeInput(videoFramesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(cancellationToken)
             .ProcessSynchronously());
     }
 
@@ -161,17 +168,17 @@ public class VideoTest
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task Video_ToMP4_Args_Pipe_DifferentImageSizes_WindowsOnly_Async()
     {
-        await Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal_Async(PixelFormat.Format24bppRgb);
+        await Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal_Async(PixelFormat.Format24bppRgb, TestContext.CancellationToken);
     }
 
     [TestMethod]
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task Video_ToMP4_Args_Pipe_DifferentImageSizes_Async()
     {
-        await Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal_Async(SKColorType.Rgb565);
+        await Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal_Async(SKColorType.Rgb565, TestContext.CancellationToken);
     }
 
-    private static async Task Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal_Async(dynamic pixelFormat)
+    private static async Task Video_ToMP4_Args_Pipe_DifferentImageSizes_Internal_Async(dynamic pixelFormat, CancellationToken cancellationToken)
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
@@ -185,6 +192,7 @@ public class VideoTest
             .FromPipeInput(videoFramesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(cancellationToken)
             .ProcessAsynchronously());
     }
 
@@ -194,19 +202,21 @@ public class VideoTest
     public void Video_ToMP4_Args_Pipe_DifferentPixelFormats_WindowsOnly()
     {
         Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal(PixelFormat.Format24bppRgb,
-            PixelFormat.Format32bppRgb);
+            PixelFormat.Format32bppRgb, TestContext.CancellationToken);
     }
 
     [TestMethod]
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Video_ToMP4_Args_Pipe_DifferentPixelFormats()
     {
-        Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal(SKColorType.Rgb565, SKColorType.Bgra8888);
+        Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal(SKColorType.Rgb565, SKColorType.Bgra8888, TestContext.CancellationToken);
     }
 
-    private static void Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal(dynamic pixelFormatFrame1, dynamic pixelFormatFrame2)
+    private static void Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal(dynamic pixelFormatFrame1, dynamic pixelFormatFrame2,
+        CancellationToken cancellationToken)
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
+
 
         var frames = new List<IVideoFrame>
         {
@@ -218,6 +228,7 @@ public class VideoTest
             .FromPipeInput(videoFramesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(cancellationToken)
             .ProcessSynchronously());
     }
 
@@ -227,17 +238,18 @@ public class VideoTest
     public async Task Video_ToMP4_Args_Pipe_DifferentPixelFormats_WindowsOnly_Async()
     {
         await Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal_Async(PixelFormat.Format24bppRgb,
-            PixelFormat.Format32bppRgb);
+            PixelFormat.Format32bppRgb, TestContext.CancellationToken);
     }
 
     [TestMethod]
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public async Task Video_ToMP4_Args_Pipe_DifferentPixelFormats_Async()
     {
-        await Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal_Async(SKColorType.Rgb565, SKColorType.Bgra8888);
+        await Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal_Async(SKColorType.Rgb565, SKColorType.Bgra8888, TestContext.CancellationToken);
     }
 
-    private static async Task Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal_Async(dynamic pixelFormatFrame1, dynamic pixelFormatFrame2)
+    private static async Task Video_ToMP4_Args_Pipe_DifferentPixelFormats_Internal_Async(dynamic pixelFormatFrame1, dynamic pixelFormatFrame2,
+        CancellationToken cancellationToken)
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
 
@@ -251,6 +263,7 @@ public class VideoTest
             .FromPipeInput(videoFramesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(cancellationToken)
             .ProcessAsynchronously());
     }
 
@@ -265,6 +278,7 @@ public class VideoTest
             .FromPipeInput(new StreamPipeSource(input))
             .OutputToFile(output, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -280,6 +294,7 @@ public class VideoTest
             await FFMpegArguments
                 .FromFileInput(TestResources.Mp4Video)
                 .OutputToPipe(pipeSource, opt => opt.ForceFormat("mp4"))
+                .CancellableThrough(TestContext.CancellationToken)
                 .ProcessAsynchronously();
         });
     }
@@ -295,6 +310,7 @@ public class VideoTest
                 .ForceFormat("webm"))
             .OutputToPipe(new StreamPipeSink(output), opt => opt
                 .ForceFormat("mpegts"))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         output.Position = 0;
@@ -313,6 +329,7 @@ public class VideoTest
                 .FromFileInput(TestResources.Mp4Video)
                 .OutputToPipe(new StreamPipeSink(ms), opt => opt
                     .ForceFormat("mkv"))
+                .CancellableThrough(TestContext.CancellationToken)
                 .ProcessSynchronously();
         });
     }
@@ -328,6 +345,7 @@ public class VideoTest
             .OutputToPipe(pipeSource, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264)
                 .ForceFormat("matroska"))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously();
     }
 
@@ -338,11 +356,13 @@ public class VideoTest
         FFMpegArguments
             .FromFileInput(TestResources.Mp4Video)
             .OutputToFile("temporary.mp4")
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         await FFMpegArguments
             .FromFileInput(TestResources.Mp4Video)
             .OutputToFile("temporary.mp4")
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously();
 
         File.Delete("temporary.mp4");
@@ -358,6 +378,7 @@ public class VideoTest
             .OutputToPipe(new StreamPipeSink(output), opt => opt
                 .WithVideoCodec(VideoCodec.LibVpx)
                 .ForceFormat("matroska"))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
 
@@ -376,6 +397,7 @@ public class VideoTest
         var success = FFMpegArguments
             .FromFileInput(TestResources.Mp4Video)
             .OutputToFile(outputFile, false)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -392,6 +414,7 @@ public class VideoTest
                 .CopyChannel()
                 .WithBitStreamFilter(Channel.Video, Filter.H264_Mp4ToAnnexB)
                 .ForceFormat(VideoType.MpegTs))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -403,7 +426,7 @@ public class VideoTest
     [DataRow(PixelFormat.Format32bppArgb)]
     public async Task Video_ToTS_Args_Pipe_WindowsOnly(PixelFormat pixelFormat)
     {
-        await Video_ToTS_Args_Pipe_Internal(pixelFormat);
+        await Video_ToTS_Args_Pipe_Internal(pixelFormat, TestContext.CancellationToken);
     }
 
     [TestMethod]
@@ -412,10 +435,10 @@ public class VideoTest
     [DataRow(SKColorType.Bgra8888)]
     public async Task Video_ToTS_Args_Pipe(SKColorType pixelFormat)
     {
-        await Video_ToTS_Args_Pipe_Internal(pixelFormat);
+        await Video_ToTS_Args_Pipe_Internal(pixelFormat, TestContext.CancellationToken);
     }
 
-    private static async Task Video_ToTS_Args_Pipe_Internal(dynamic pixelFormat)
+    private static async Task Video_ToTS_Args_Pipe_Internal(dynamic pixelFormat, CancellationToken cancellationToken)
     {
         using var output = new TemporaryFile($"out{VideoType.Ts.Extension}");
         var input = new RawVideoPipeSource(BitmapSource.CreateBitmaps(128, pixelFormat, 256, 256));
@@ -424,6 +447,7 @@ public class VideoTest
             .FromPipeInput(input)
             .OutputToFile(output, false, opt => opt
                 .ForceFormat(VideoType.Ts))
+            .CancellableThrough(cancellationToken)
             .ProcessAsynchronously();
         Assert.IsTrue(success);
 
@@ -441,6 +465,7 @@ public class VideoTest
             .OutputToFile(outputFile, false, opt => opt
                 .Resize(200, 200)
                 .WithVideoCodec(VideoCodec.LibTheora))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously();
         Assert.IsTrue(success);
     }
@@ -461,6 +486,7 @@ public class VideoTest
                 .WithVideoFilters(filterOptions => filterOptions
                     .Scale(VideoSize.Ed))
                 .WithVideoCodec(VideoCodec.LibTheora))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         var analysis = FFProbe.Analyse(outputFile);
@@ -478,6 +504,7 @@ public class VideoTest
             .OutputToFile(outputFile, false, opt => opt
                 .UsingMultithreading(true)
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -490,7 +517,7 @@ public class VideoTest
     // [DataRow(PixelFormat.Format48bppRgb)]
     public void Video_ToMP4_Resize_Args_Pipe(PixelFormat pixelFormat)
     {
-        Video_ToMP4_Resize_Args_Pipe_Internal(pixelFormat);
+        Video_ToMP4_Resize_Args_Pipe_Internal(pixelFormat, TestContext.CancellationToken);
     }
 
     [TestMethod]
@@ -499,10 +526,10 @@ public class VideoTest
     [DataRow(SKColorType.Bgra8888)]
     public void Video_ToMP4_Resize_Args_Pipe(SKColorType pixelFormat)
     {
-        Video_ToMP4_Resize_Args_Pipe_Internal(pixelFormat);
+        Video_ToMP4_Resize_Args_Pipe_Internal(pixelFormat, TestContext.CancellationToken);
     }
 
-    private static void Video_ToMP4_Resize_Args_Pipe_Internal(dynamic pixelFormat)
+    private static void Video_ToMP4_Resize_Args_Pipe_Internal(dynamic pixelFormat, CancellationToken cancellationToken)
     {
         using var outputFile = new TemporaryFile($"out{VideoType.Mp4.Extension}");
         var videoFramesSource = new RawVideoPipeSource(BitmapSource.CreateBitmaps(128, pixelFormat, 256, 256));
@@ -511,6 +538,7 @@ public class VideoTest
             .FromPipeInput(videoFramesSource)
             .OutputToFile(outputFile, false, opt => opt
                 .WithVideoCodec(VideoCodec.LibX264))
+            .CancellableThrough(cancellationToken)
             .ProcessSynchronously();
         Assert.IsTrue(success);
     }
@@ -764,6 +792,7 @@ public class VideoTest
         FFMpegArguments
             .FromFileInput(TestResources.Mp4Video)
             .OutputToFile(outputFile, false, opt => opt.WithDuration(TimeSpan.FromSeconds(video.Duration.TotalSeconds - 2)))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         Assert.IsTrue(File.Exists(outputFile));
@@ -807,6 +836,7 @@ public class VideoTest
                 .WithDuration(analysis.Duration))
             .NotifyOnProgress(OnPercentageProgess, analysis.Duration)
             .NotifyOnProgress(OnTimeProgess)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         Assert.IsTrue(success);
@@ -832,6 +862,7 @@ public class VideoTest
                 .WithDuration(TimeSpan.FromSeconds(2)))
             .NotifyOnError(_ => dataReceived = true)
             .Configure(opt => opt.Encoding = Encoding.UTF8)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         Assert.IsTrue(dataReceived);
@@ -844,17 +875,17 @@ public class VideoTest
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Video_TranscodeInMemory_WindowsOnly()
     {
-        Video_TranscodeInMemory_Internal(PixelFormat.Format24bppRgb);
+        Video_TranscodeInMemory_Internal(PixelFormat.Format24bppRgb, TestContext.CancellationToken);
     }
 
     [TestMethod]
     [Timeout(BaseTimeoutMilliseconds, CooperativeCancellation = true)]
     public void Video_TranscodeInMemory()
     {
-        Video_TranscodeInMemory_Internal(SKColorType.Rgb565);
+        Video_TranscodeInMemory_Internal(SKColorType.Rgb565, TestContext.CancellationToken);
     }
 
-    private static void Video_TranscodeInMemory_Internal(dynamic pixelFormat)
+    private static void Video_TranscodeInMemory_Internal(dynamic pixelFormat, CancellationToken cancellationToken)
     {
         using var resStream = new MemoryStream();
         var reader = new StreamPipeSink(resStream);
@@ -865,6 +896,7 @@ public class VideoTest
             .OutputToPipe(reader, opt => opt
                 .WithVideoCodec("vp9")
                 .ForceFormat("webm"))
+            .CancellableThrough(cancellationToken)
             .ProcessSynchronously();
 
         resStream.Position = 0;
@@ -884,6 +916,7 @@ public class VideoTest
             .OutputToPipe(new StreamPipeSink(memoryStream), opt => opt
                 .WithVideoCodec("vp9")
                 .ForceFormat("webm"))
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessSynchronously();
 
         memoryStream.Position = 0;
@@ -907,6 +940,8 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(out var cancel)
+            .CancellableThrough(TestContext.CancellationToken)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously(false);
 
         await Task.Delay(300, TestContext.CancellationToken);
@@ -930,11 +965,13 @@ public class VideoTest
                 .WithAudioCodec(AudioCodec.Aac)
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
-            .CancellableThrough(out var cancel);
+            .CancellableThrough(out var cancel)
+            .CancellableThrough(TestContext.CancellationToken);
 
         Task.Delay(300, TestContext.CancellationToken).ContinueWith(_ => cancel(), TestContext.CancellationToken);
 
-        var result = task.ProcessSynchronously(false);
+        var result = task.CancellableThrough(TestContext.CancellationToken)
+            .ProcessSynchronously(false);
 
         Assert.IsFalse(result);
     }
@@ -954,6 +991,7 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(out var cancel, 10000)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously(false);
 
         await Task.Delay(300, TestContext.CancellationToken);
@@ -987,6 +1025,7 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(cts.Token)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously(false);
 
         cts.CancelAfter(300);
@@ -1013,6 +1052,7 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(cts.Token)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously();
 
         cts.CancelAfter(300);
@@ -1040,7 +1080,8 @@ public class VideoTest
 
         cts.CancelAfter(300);
 
-        Assert.ThrowsExactly<OperationCanceledException>(() => task.ProcessSynchronously());
+        Assert.ThrowsExactly<OperationCanceledException>(() => task.CancellableThrough(TestContext.CancellationToken)
+            .ProcessSynchronously());
     }
 
     [TestMethod]
@@ -1062,7 +1103,8 @@ public class VideoTest
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(cts.Token);
 
-        Assert.ThrowsExactly<OperationCanceledException>(() => task.ProcessSynchronously());
+        Assert.ThrowsExactly<OperationCanceledException>(() => task.CancellableThrough(TestContext.CancellationToken)
+            .ProcessSynchronously());
     }
 
     [TestMethod]
@@ -1082,6 +1124,7 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(cts.Token, 8000)
+            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously(false);
 
         cts.CancelAfter(300);

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -1123,7 +1123,6 @@ public class VideoTest
                 .WithVideoCodec(VideoCodec.LibX264)
                 .WithSpeedPreset(Speed.VeryFast))
             .CancellableThrough(cts.Token, 8000)
-            .CancellableThrough(TestContext.CancellationToken)
             .ProcessAsynchronously(false);
 
         cts.CancelAfter(300);

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -812,9 +812,10 @@ public class VideoTest
         Assert.IsTrue(success);
         Assert.IsTrue(File.Exists(outputFile));
         Assert.AreNotEqual(0.0, percentageDone);
+        Assert.IsGreaterThan(1, events.Count);
         CollectionAssert.AllItemsAreUnique(events);
         Assert.AreNotEqual(100.0, events.First());
-        Assert.AreEqual(100.0, events.Last());
+        Assert.AreEqual(100.0, events.Last(), 0.001);
         Assert.AreNotEqual(TimeSpan.Zero, timeDone);
         Assert.AreNotEqual(analysis.Duration, timeDone);
     }

--- a/FFMpegCore.Test/VideoTest.cs
+++ b/FFMpegCore.Test/VideoTest.cs
@@ -785,12 +785,12 @@ public class VideoTest
         var timeDone = TimeSpan.Zero;
         var analysis = FFProbe.Analyse(TestResources.Mp4Video);
 
+        var events = new List<double>();
+
         void OnPercentageProgess(double percentage)
         {
-            if (percentage < 100)
-            {
-                percentageDone = percentage;
-            }
+            events.Add(percentage);
+            percentageDone = percentage;
         }
 
         void OnTimeProgess(TimeSpan time)
@@ -812,7 +812,9 @@ public class VideoTest
         Assert.IsTrue(success);
         Assert.IsTrue(File.Exists(outputFile));
         Assert.AreNotEqual(0.0, percentageDone);
-        Assert.AreNotEqual(100.0, percentageDone);
+        CollectionAssert.AllItemsAreUnique(events);
+        Assert.AreNotEqual(100.0, events.First());
+        Assert.AreEqual(100.0, events.Last());
         Assert.AreNotEqual(TimeSpan.Zero, timeDone);
         Assert.AreNotEqual(analysis.Duration, timeDone);
     }

--- a/FFMpegCore/FFMetadataInputArgument.cs
+++ b/FFMpegCore/FFMetadataInputArgument.cs
@@ -1,0 +1,63 @@
+using System.Text;
+
+namespace FFMpegCore;
+
+public class FFMetadataBuilder
+{
+    private Dictionary<string, string> Tags { get; } = new();
+    private List<FFMetadataChapter> Chapters { get; } = [];
+
+    public static FFMetadataBuilder Empty()
+    {
+        return new FFMetadataBuilder();
+    }
+
+    public FFMetadataBuilder WithTag(string key, string value)
+    {
+        Tags.Add(key, value);
+        return this;
+    }
+
+    public FFMetadataBuilder WithChapter(string title, long durationMs)
+    {
+        Chapters.Add(new FFMetadataChapter(title, durationMs));
+        return this;
+    }
+
+    public FFMetadataBuilder WithChapter(string title, double durationSeconds)
+    {
+        Chapters.Add(new FFMetadataChapter(title, Convert.ToInt64(durationSeconds * 1000)));
+        return this;
+    }
+
+    public string GetMetadataFileContent()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(";FFMETADATA1");
+
+        foreach (var tag in Tags)
+        {
+            sb.AppendLine($"{tag.Key}={tag.Value}");
+        }
+
+        long totalDurationMs = 0;
+        foreach (var chapter in Chapters)
+        {
+            sb.AppendLine("[CHAPTER]");
+            sb.AppendLine("TIMEBASE=1/1000");
+            sb.AppendLine($"START={totalDurationMs}");
+            sb.AppendLine($"END={totalDurationMs + chapter.DurationMs}");
+            sb.AppendLine($"title={chapter.Title}");
+            totalDurationMs += chapter.DurationMs;
+        }
+
+        return sb.ToString();
+    }
+
+
+    private class FFMetadataChapter(string title, long durationMs)
+    {
+        public string Title { get; } = title;
+        public long DurationMs { get; } = durationMs;
+    }
+}

--- a/FFMpegCore/FFMetadataInputArgument.cs
+++ b/FFMpegCore/FFMetadataInputArgument.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace FFMpegCore;
 

--- a/FFMpegCore/FFMetadataInputArgument.cs
+++ b/FFMpegCore/FFMetadataInputArgument.cs
@@ -54,7 +54,6 @@ public class FFMetadataBuilder
         return sb.ToString();
     }
 
-
     private class FFMetadataChapter(string title, long durationMs)
     {
         public string Title { get; } = title;

--- a/FFMpegCore/FFMpeg/Arguments/GifPaletteArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/GifPaletteArgument.cs
@@ -4,12 +4,11 @@ namespace FFMpegCore.Arguments;
 
 public class GifPaletteArgument : IArgument
 {
-    private readonly int _fps;
-
+    private readonly double _fps;
     private readonly Size? _size;
     private readonly int _streamIndex;
 
-    public GifPaletteArgument(int streamIndex, int fps, Size? size)
+    public GifPaletteArgument(int streamIndex, double fps, Size? size)
     {
         _streamIndex = streamIndex;
         _fps = fps;

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -37,16 +37,19 @@ public static class FFMpeg
     /// <param name="size">Thumbnail size. If width or height equal 0, the other will be computed automatically.</param>
     /// <param name="streamIndex">Selected video stream index.</param>
     /// <param name="inputFileIndex">Input file index</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Bitmap with the requested snapshot.</returns>
     public static async Task<bool> SnapshotAsync(string input, string output, Size? size = null, TimeSpan? captureTime = null, int? streamIndex = null,
-        int inputFileIndex = 0)
+        int inputFileIndex = 0, CancellationToken cancellationToken = default)
     {
         CheckSnapshotOutputExtension(output, FileExtension.Image.All);
 
-        var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
+        var source = await FFProbe.AnalyseAsync(input, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return await SnapshotProcess(input, output, source, size, captureTime, streamIndex, inputFileIndex)
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
     }
 
     public static bool GifSnapshot(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null,
@@ -61,14 +64,16 @@ public static class FFMpeg
     }
 
     public static async Task<bool> GifSnapshotAsync(string input, string output, Size? size = null, TimeSpan? captureTime = null, TimeSpan? duration = null,
-        int? streamIndex = null)
+        int? streamIndex = null, CancellationToken cancellationToken = default)
     {
         CheckSnapshotOutputExtension(output, [FileExtension.Gif]);
 
-        var source = await FFProbe.AnalyseAsync(input).ConfigureAwait(false);
+        var source = await FFProbe.AnalyseAsync(input, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return await GifSnapshotProcess(input, output, source, size, captureTime, duration, streamIndex)
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
     }
 
     private static FFMpegArgumentProcessor SnapshotProcess(string input, string output, IMediaAnalysis source, Size? size = null, TimeSpan? captureTime = null,
@@ -321,11 +326,15 @@ public static class FFMpeg
     /// <param name="output">Output video file.</param>
     /// <param name="startTime">The start time of when the sub video needs to start</param>
     /// <param name="endTime">The end time of where the sub video needs to  end</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Output video information.</returns>
-    public static async Task<bool> SubVideoAsync(string input, string output, TimeSpan startTime, TimeSpan endTime)
+    public static async Task<bool> SubVideoAsync(string input, string output, TimeSpan startTime, TimeSpan endTime,
+        CancellationToken cancellationToken = default)
     {
         return await BaseSubVideo(input, output, startTime, endTime)
-            .ProcessAsynchronously();
+            .CancellableThrough(cancellationToken)
+            .ProcessAsynchronously()
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/FFMpegCore/FFMpeg/FFMpeg.cs
+++ b/FFMpegCore/FFMpeg/FFMpeg.cs
@@ -132,7 +132,8 @@ public static class FFMpeg
             }
 
             return FFMpegArguments
-                .FromFileInput(Path.Combine(tempFolderName, $"%09d{fileExtension}"), false)
+                .FromFileInput(Path.Combine(tempFolderName, $"%09d{fileExtension}"), false, options => options
+                    .WithFramerate(frameRate))
                 .OutputToFile(output, true, options => options
                     .ForcePixelFormat("yuv420p")
                     .Resize(width!.Value, height!.Value)

--- a/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentOptions.cs
@@ -258,7 +258,7 @@ public class FFMpegArgumentOptions : FFMpegArgumentsBase
         return WithArgument(new ID3V2VersionArgument(id3v2Version));
     }
 
-    public FFMpegArgumentOptions WithGifPaletteArgument(int streamIndex, Size? size, int fps = 12)
+    public FFMpegArgumentOptions WithGifPaletteArgument(int streamIndex, Size? size, double fps = 12)
     {
         return WithArgument(new GifPaletteArgument(streamIndex, fps, size));
     }

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -78,23 +78,22 @@ public class FFMpegArgumentProcessor
         return this;
     }
 
+    private void Cancel(int timeout)
+    {
+        _cancelled = true;
+        CancelEvent?.Invoke(this, timeout);
+    }
+
     public FFMpegArgumentProcessor CancellableThrough(out Action cancel, int timeout = 0)
     {
-        cancel = () =>
-        {
-            _cancelled = true;
-            CancelEvent?.Invoke(this, timeout);
-        };
+        cancel = () => Cancel(timeout);
         return this;
     }
 
+
     public FFMpegArgumentProcessor CancellableThrough(CancellationToken token, int timeout = 0)
     {
-        _cancellationTokenRegistration = token.Register(() =>
-        {
-            _cancelled = true;
-            CancelEvent?.Invoke(this, timeout);
-        });
+        _cancellationTokenRegistration = token.Register(() => Cancel(timeout));
         return this;
     }
 

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -90,7 +90,6 @@ public class FFMpegArgumentProcessor
         return this;
     }
 
-
     public FFMpegArgumentProcessor CancellableThrough(CancellationToken token, int timeout = 0)
     {
         _cancellationTokenRegistration = token.Register(() => Cancel(timeout));

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -166,12 +166,28 @@ public class FFMpegArgumentProcessor
 
         void OnCancelEvent(object sender, int timeout)
         {
-            instance.SendInput("q");
+            ExecuteIgnoringFinishedProcessExceptions(() => instance.SendInput("q"));
 
             if (!cancellationTokenSource.Token.WaitHandle.WaitOne(timeout, true))
             {
                 cancellationTokenSource.Cancel();
-                instance.Kill();
+                ExecuteIgnoringFinishedProcessExceptions(() => instance.Kill());
+            }
+
+            static void ExecuteIgnoringFinishedProcessExceptions(Action action)
+            {
+                try
+                {
+                    action();
+                }
+                catch (Instances.Exceptions.InstanceProcessAlreadyExitedException)
+                {
+                    //ignore
+                }
+                catch (ObjectDisposedException)
+                {
+                    //ignore
+                }
             }
         }
 

--- a/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArgumentProcessor.cs
@@ -10,8 +10,11 @@ namespace FFMpegCore;
 public class FFMpegArgumentProcessor
 {
     private static readonly Regex ProgressRegex = new(@"time=(\d\d:\d\d:\d\d.\d\d?)", RegexOptions.Compiled);
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly List<Action<FFOptions>> _configurations;
     private readonly FFMpegArguments _ffMpegArguments;
+    private CancellationTokenRegistration? _cancellationTokenRegistration;
+    private bool _cancelled;
     private FFMpegLogLevel? _logLevel;
     private Action<string>? _onError;
     private Action<string>? _onOutput;
@@ -28,6 +31,12 @@ public class FFMpegArgumentProcessor
     public string Arguments => _ffMpegArguments.Text;
 
     private event EventHandler<int> CancelEvent = null!;
+
+    ~FFMpegArgumentProcessor()
+    {
+        _cancellationTokenSource.Dispose();
+        _cancellationTokenRegistration?.Dispose();
+    }
 
     /// <summary>
     ///     Register action that will be invoked during the ffmpeg processing, when a progress time is output and parsed and progress percentage is
@@ -71,13 +80,21 @@ public class FFMpegArgumentProcessor
 
     public FFMpegArgumentProcessor CancellableThrough(out Action cancel, int timeout = 0)
     {
-        cancel = () => CancelEvent?.Invoke(this, timeout);
+        cancel = () =>
+        {
+            _cancelled = true;
+            CancelEvent?.Invoke(this, timeout);
+        };
         return this;
     }
 
     public FFMpegArgumentProcessor CancellableThrough(CancellationToken token, int timeout = 0)
     {
-        token.Register(() => CancelEvent?.Invoke(this, timeout));
+        _cancellationTokenRegistration = token.Register(() =>
+        {
+            _cancelled = true;
+            CancelEvent?.Invoke(this, timeout);
+        });
         return this;
     }
 
@@ -101,12 +118,12 @@ public class FFMpegArgumentProcessor
     public bool ProcessSynchronously(bool throwOnError = true, FFOptions? ffMpegOptions = null)
     {
         var options = GetConfiguredOptions(ffMpegOptions);
-        var processArguments = PrepareProcessArguments(options, out var cancellationTokenSource);
+        var processArguments = PrepareProcessArguments(options);
 
         IProcessResult? processResult = null;
         try
         {
-            processResult = Process(processArguments, cancellationTokenSource).ConfigureAwait(false).GetAwaiter().GetResult();
+            processResult = Process(processArguments).ConfigureAwait(false).GetAwaiter().GetResult();
         }
         catch (OperationCanceledException)
         {
@@ -122,12 +139,12 @@ public class FFMpegArgumentProcessor
     public async Task<bool> ProcessAsynchronously(bool throwOnError = true, FFOptions? ffMpegOptions = null)
     {
         var options = GetConfiguredOptions(ffMpegOptions);
-        var processArguments = PrepareProcessArguments(options, out var cancellationTokenSource);
+        var processArguments = PrepareProcessArguments(options);
 
         IProcessResult? processResult = null;
         try
         {
-            processResult = await Process(processArguments, cancellationTokenSource).ConfigureAwait(false);
+            processResult = await Process(processArguments).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -140,23 +157,25 @@ public class FFMpegArgumentProcessor
         return HandleCompletion(throwOnError, processResult?.ExitCode ?? -1, processResult?.ErrorData ?? Array.Empty<string>());
     }
 
-    private async Task<IProcessResult> Process(ProcessArguments processArguments, CancellationTokenSource cancellationTokenSource)
+    private async Task<IProcessResult> Process(ProcessArguments processArguments)
     {
         IProcessResult processResult = null!;
+        if (_cancelled)
+        {
+            throw new OperationCanceledException("cancelled before starting processing");
+        }
 
         _ffMpegArguments.Pre();
 
         using var instance = processArguments.Start();
-        var cancelled = false;
 
         void OnCancelEvent(object sender, int timeout)
         {
-            cancelled = true;
             instance.SendInput("q");
 
-            if (!cancellationTokenSource.Token.WaitHandle.WaitOne(timeout, true))
+            if (!_cancellationTokenSource.Token.WaitHandle.WaitOne(timeout, true))
             {
-                cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Cancel();
                 instance.Kill();
             }
         }
@@ -168,11 +187,11 @@ public class FFMpegArgumentProcessor
             await Task.WhenAll(instance.WaitForExitAsync().ContinueWith(t =>
             {
                 processResult = t.Result;
-                cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Cancel();
                 _ffMpegArguments.Post();
-            }), _ffMpegArguments.During(cancellationTokenSource.Token)).ConfigureAwait(false);
+            }), _ffMpegArguments.During(_cancellationTokenSource.Token)).ConfigureAwait(false);
 
-            if (cancelled)
+            if (_cancelled)
             {
                 throw new OperationCanceledException("ffmpeg processing was cancelled");
             }
@@ -214,8 +233,7 @@ public class FFMpegArgumentProcessor
         return options;
     }
 
-    private ProcessArguments PrepareProcessArguments(FFOptions ffOptions,
-        out CancellationTokenSource cancellationTokenSource)
+    private ProcessArguments PrepareProcessArguments(FFOptions ffOptions)
     {
         FFMpegHelper.RootExceptionCheck();
         FFMpegHelper.VerifyFFMpegExists(ffOptions);
@@ -245,7 +263,6 @@ public class FFMpegArgumentProcessor
             WorkingDirectory = ffOptions.WorkingDirectory
         };
         var processArguments = new ProcessArguments(startInfo);
-        cancellationTokenSource = new CancellationTokenSource();
 
         if (_onOutput != null)
         {

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -109,6 +109,11 @@ public sealed class FFMpegArguments : FFMpegArgumentsBase
         return WithInput(new MetaDataArgument(content), addArguments);
     }
 
+    public FFMpegArguments AddMetaData(FFMetadataBuilder metaDataBuilder, Action<FFMpegArgumentOptions>? addArguments = null)
+    {
+        return WithInput(new MetaDataArgument(metaDataBuilder.GetMetadataFileContent()), addArguments);
+    }
+
     public FFMpegArguments AddMetaData(IReadOnlyMetaData metaData, Action<FFMpegArgumentOptions>? addArguments = null)
     {
         return WithInput(new MetaDataArgument(MetaDataSerializer.Instance.Serialize(metaData)), addArguments);

--- a/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
+++ b/FFMpegCore/FFMpeg/SnapshotArgumentBuilder.cs
@@ -62,7 +62,7 @@ public static class SnapshotArgumentBuilder
         TimeSpan? captureTime = null,
         TimeSpan? duration = null,
         int? streamIndex = null,
-        int fps = 12)
+        double fps = 12)
     {
         var defaultGifOutputSize = new Size(480, -1);
 

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -7,6 +7,7 @@
     <PackageOutputPath>../nupkg</PackageOutputPath>
     <PackageReleaseNotes>
       - Fixed exception thrown on cancelling ffprobe analysis - by snechaev
+      - Support for cancellationtoken in SnapsnotAsync methods - by snechaev
       - Added FFMetadataBuilder - by rosenbjerg
       - Fix JoinImageSequence by passing framerate argument to input as well as output - by rosenbjerg
       - Change fps input from int to double - by rosenbjerg

--- a/FFMpegCore/FFMpegCore.csproj
+++ b/FFMpegCore/FFMpegCore.csproj
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Description>A .NET Standard FFMpeg/FFProbe wrapper for easily integrating media analysis and conversion into your .NET applications</Description>
-    <PackageVersion>5.3.0</PackageVersion>
+    <PackageVersion>5.4.0</PackageVersion>
     <PackageOutputPath>../nupkg</PackageOutputPath>
     <PackageReleaseNotes>
-      - **Fixed race condition on Named pipe dispose/disconnect** by techtel-pstevens
-      - **More extensions for snapshot function(jpg, bmp, webp)** by GorobVictor
-      - **Include more GUID characters in pipe path** by reima, rosenbjerg
-      - **Updated dependencies and minor cleanup**: by rosenbjerg
+      - Fixed exception thrown on cancelling ffprobe analysis - by snechaev
+      - Added FFMetadataBuilder - by rosenbjerg
+      - Fix JoinImageSequence by passing framerate argument to input as well as output - by rosenbjerg
+      - Change fps input from int to double - by rosenbjerg
+      - Fix GetCreationTime method on ITagsContainer - by rosenbjerg
     </PackageReleaseNotes>
     <PackageTags>ffmpeg ffprobe convert video audio mediafile resize analyze muxing</PackageTags>
     <Authors>Malte Rosenbjerg, Vlad Jerca, Max Bagryantsev</Authors>

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -214,11 +214,11 @@ public static class FFProbe
 
     private static void ThrowIfExitCodeNotZero(IProcessResult result, CancellationToken cancellationToken = default)
     {
-        // if cancellation requested, then we are not interested in the exit code, just throw the cancellation exception
-        // to get consistent and expected behavior.
-        cancellationToken.ThrowIfCancellationRequested();
         if (result.ExitCode != 0)
         {
+            // if cancellation requested, then we are not interested in the exit code, just throw the cancellation exception
+            // to get consistent and expected behavior.
+            cancellationToken.ThrowIfCancellationRequested();
             var message = $"ffprobe exited with non-zero exit-code ({result.ExitCode} - {string.Join("\n", result.ErrorData)})";
             throw new FFMpegException(FFMpegExceptionType.Process, message, null, string.Join("\n", result.ErrorData));
         }

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -151,7 +151,7 @@ public static class TagExtensions
 
     public static string? GetCreationTime(this ITagsContainer tagsContainer)
     {
-        return TryGetTagValue(tagsContainer, "creation_time ");
+        return TryGetTagValue(tagsContainer, "creation_time");
     }
 
     public static string? GetRotate(this ITagsContainer tagsContainer)

--- a/FFMpegCore/FFProbe/ProcessArgumentsExtensions.cs
+++ b/FFMpegCore/FFProbe/ProcessArgumentsExtensions.cs
@@ -13,6 +13,6 @@ public static class ProcessArgumentsExtensions
     public static async Task<IProcessResult> StartAndWaitForExitAsync(this ProcessArguments processArguments, CancellationToken cancellationToken = default)
     {
         using var instance = processArguments.Start();
-        return await instance.WaitForExitAsync(cancellationToken);
+        return await instance.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
- Fixed exception thrown on cancelling ffprobe analysis - by snechaev
- Support for cancellationtoken in SnapsnotAsync methods - by snechaev
- Added FFMetadataBuilder - by rosenbjerg
- Fix JoinImageSequence by passing framerate argument to input as well as output - by rosenbjerg
- Change fps input from int to double - by rosenbjerg
- Fix GetCreationTime method on ITagsContainer - by rosenbjerg