### PR TITLE
Change private WithArgument methods to public

### DIFF
--- a/FFMpegCore/FFMpeg/Arguments/VideoFiltersArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/VideoFiltersArgument.cs
@@ -94,7 +94,7 @@ public class VideoFilterOptions
         return WithArgument(new PadArgument(padOptions));
     }
 
-    private VideoFilterOptions WithArgument(IVideoFilterArgument argument)
+    public VideoFilterOptions WithArgument(IVideoFilterArgument argument)
     {
         Arguments.Add(argument);
         return this;

--- a/FFMpegCore/FFMpeg/FFMpegGlobalArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegGlobalArguments.cs
@@ -8,10 +8,10 @@ public sealed class FFMpegGlobalArguments : FFMpegArgumentsBase
 
     public FFMpegGlobalArguments WithVerbosityLevel(VerbosityLevel verbosityLevel = VerbosityLevel.Error)
     {
-        return WithOption(new VerbosityLevelArgument(verbosityLevel));
+        return WithArgument(new VerbosityLevelArgument(verbosityLevel));
     }
 
-    private FFMpegGlobalArguments WithOption(IArgument argument)
+    public FFMpegGlobalArguments WithArgument(IArgument argument)
     {
         Arguments.Add(argument);
         return this;


### PR DESCRIPTION
FFMpegArgumentOptions.WithArgument is already public, which allows extensions.
However, this is not nice semantically, as the global arguments (e.g. `-hide_banner`, `-nostats`) have to be given as input arguments.

So I changed the other two methods of the classes `FFMpegGlobalArguments` and `VideoFilterOptions` from `private` to `public` to allow an extension here as well.
I have changed the name of the method `FFMpegGlobalArguments.WithOption()` to `FFMpegGlobalArguments.WithArgument()` so that it is consistent.