### PR TITLE
Added overloads to the `FFProbe.GetFrames` and `FFProbe.GetFramesAsync` methods to allow passing in Stream objects

### DIFF
--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -31,9 +31,35 @@ public class FFProbeTests
     }
 
     [TestMethod]
+    public void FrameAnalysis_FromStream_Sync()
+    {
+        using var stream = File.OpenRead(TestResources.WebmVideo);
+        var frameAnalysis = FFProbe.GetFrames(stream);
+
+        Assert.HasCount(90, frameAnalysis.Frames);
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.PixelFormat == "yuv420p"));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.Height == 360));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.Width == 640));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.MediaType == "video"));
+    }
+
+    [TestMethod]
     public async Task FrameAnalysis_Async()
     {
         var frameAnalysis = await FFProbe.GetFramesAsync(TestResources.WebmVideo, cancellationToken: TestContext.CancellationToken);
+
+        Assert.HasCount(90, frameAnalysis.Frames);
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.PixelFormat == "yuv420p"));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.Height == 360));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.Width == 640));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.MediaType == "video"));
+    }
+
+    [TestMethod]
+    public async Task FrameAnalysis_FromStream_Async()
+    {
+        using var stream = File.OpenRead(TestResources.WebmVideo);
+        var frameAnalysis = await FFProbe.GetFramesAsync(stream, cancellationToken: TestContext.CancellationToken);
 
         Assert.HasCount(90, frameAnalysis.Frames);
         Assert.IsTrue(frameAnalysis.Frames.All(f => f.PixelFormat == "yuv420p"));

--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -44,6 +44,18 @@ public class FFProbeTests
     }
 
     [TestMethod]
+    public void FrameAnalysis_FromUri_Sync()
+    {
+        var frameAnalysis = FFProbe.GetFrames(new Uri(Path.GetFullPath(TestResources.WebmVideo)));
+
+        Assert.HasCount(90, frameAnalysis.Frames);
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.PixelFormat == "yuv420p"));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.Height == 360));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.Width == 640));
+        Assert.IsTrue(frameAnalysis.Frames.All(f => f.MediaType == "video"));
+    }
+
+    [TestMethod]
     public async Task FrameAnalysis_Async()
     {
         var frameAnalysis = await FFProbe.GetFramesAsync(TestResources.WebmVideo, cancellationToken: TestContext.CancellationToken);

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -30,24 +30,13 @@ public static class FFProbe
         string? customArguments = null)
     {
         ThrowIfInputFileDoesNotExist(filePath);
-
-        var instance = PrepareStreamAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
-        cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParseOutput(result);
+        return await AnalyseCoreAsync(filePath, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
     }
 
     public static async Task<IMediaAnalysis> AnalyseAsync(Uri uri, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
         string? customArguments = null)
     {
-        var instance = PrepareStreamAnalysisInstance(uri.AbsoluteUri, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
-        cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParseOutput(result);
+        return await AnalyseCoreAsync(uri.AbsoluteUri, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
     }
 
     public static async Task<IMediaAnalysis> AnalyseAsync(Stream stream, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
@@ -55,10 +44,10 @@ public static class FFProbe
     {
         var streamPipeSource = new StreamPipeSource(stream);
         var pipeArgument = new InputPipeArgument(streamPipeSource);
-        var instance = PrepareStreamAnalysisInstance(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        pipeArgument.Pre();
 
-        var task = instance.StartAndWaitForExitAsync(cancellationToken);
+        var task = AnalyseCoreAsync(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current, cancellationToken, customArguments);
+
+        pipeArgument.Pre();
         try
         {
             await pipeArgument.During(cancellationToken).ConfigureAwait(false);
@@ -71,12 +60,7 @@ public static class FFProbe
             pipeArgument.Post();
         }
 
-        var result = await task.ConfigureAwait(false);
-        cancellationToken.ThrowIfCancellationRequested();
-        ThrowIfExitCodeNotZero(result);
-
-        pipeArgument.Post();
-        return ParseOutput(result);
+        return await task.ConfigureAwait(false);
     }
 
     public static FFProbeFrames GetFrames(string filePath, FFOptions? ffOptions = null, string? customArguments = null)
@@ -98,18 +82,13 @@ public static class FFProbe
         string? customArguments = null)
     {
         ThrowIfInputFileDoesNotExist(filePath);
-
-        var instance = PrepareFrameAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
-        return ParseFramesOutput(result);
+        return await GetFramesCoreAsync(filePath, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
     }
 
     public static async Task<FFProbeFrames> GetFramesAsync(Uri uri, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
         string? customArguments = null)
     {
-        var instance = PrepareFrameAnalysisInstance(uri.AbsoluteUri, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
-        return ParseFramesOutput(result);
+        return await GetFramesCoreAsync(uri.AbsoluteUri, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
     }
 
     public static async Task<FFProbeFrames> GetFramesAsync(Stream stream, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
@@ -117,10 +96,10 @@ public static class FFProbe
     {
         var streamPipeSource = new StreamPipeSource(stream);
         var pipeArgument = new InputPipeArgument(streamPipeSource);
-        var instance = PrepareFrameAnalysisInstance(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        pipeArgument.Pre();
 
-        var task = instance.Start().WaitForExitAsync(cancellationToken);
+        var task = GetFramesCoreAsync(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current, cancellationToken, customArguments);
+
+        pipeArgument.Pre();
         try
         {
             await pipeArgument.During(cancellationToken).ConfigureAwait(false);
@@ -131,7 +110,24 @@ public static class FFProbe
             pipeArgument.Post();
         }
 
-        var result = task.ConfigureAwait(false).GetAwaiter().GetResult();
+        return await task.ConfigureAwait(false);
+    }
+
+    private static async Task<IMediaAnalysis> AnalyseCoreAsync(string inputPath, FFOptions? ffOptions, CancellationToken cancellationToken, string? customArguments)
+    {
+        var instance = PrepareStreamAnalysisInstance(inputPath, ffOptions ?? GlobalFFOptions.Current, customArguments);
+        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfExitCodeNotZero(result);
+
+        return ParseOutput(result);
+    }
+
+    private static async Task<FFProbeFrames> GetFramesCoreAsync(string inputPath, FFOptions? ffOptions, CancellationToken cancellationToken, string? customArguments)
+    {
+        var instance = PrepareFrameAnalysisInstance(inputPath, ffOptions ?? GlobalFFOptions.Current, customArguments);
+        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
         ThrowIfExitCodeNotZero(result);
 
         return ParseFramesOutput(result);

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -36,7 +36,7 @@ public static class FFProbe
     public static async Task<IMediaAnalysis> AnalyseAsync(Uri uri, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
         string? customArguments = null)
     {
-        return await AnalyseCoreAsync(uri.AbsoluteUri, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
+        return await AnalyseCoreAsync(uri.IsFile ? uri.LocalPath : uri.AbsoluteUri, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
     }
 
     public static async Task<IMediaAnalysis> AnalyseAsync(Stream stream, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
@@ -88,7 +88,7 @@ public static class FFProbe
     public static async Task<FFProbeFrames> GetFramesAsync(Uri uri, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
         string? customArguments = null)
     {
-        return await GetFramesCoreAsync(uri.AbsoluteUri, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
+        return await GetFramesCoreAsync(uri.IsFile ? uri.LocalPath : uri.AbsoluteUri, ffOptions, cancellationToken, customArguments).ConfigureAwait(false);
     }
 
     public static async Task<FFProbeFrames> GetFramesAsync(Stream stream, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -13,73 +13,17 @@ public static class FFProbe
 {
     public static IMediaAnalysis Analyse(string filePath, FFOptions? ffOptions = null, string? customArguments = null)
     {
-        ThrowIfInputFileDoesNotExist(filePath);
-
-        var processArguments = PrepareStreamAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = processArguments.StartAndWaitForExit();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParseOutput(result);
-    }
-
-    public static FFProbeFrames GetFrames(Stream stream, FFOptions? ffOptions = null, string? customArguments = null)
-    {
-        return GetFramesAsync(stream, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
-    }
-
-    public static FFProbeFrames GetFrames(string filePath, FFOptions? ffOptions = null, string? customArguments = null)
-    {
-        ThrowIfInputFileDoesNotExist(filePath);
-
-        var instance = PrepareFrameAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = instance.StartAndWaitForExit();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParseFramesOutput(result);
-    }
-
-    public static FFProbePackets GetPackets(string filePath, FFOptions? ffOptions = null, string? customArguments = null)
-    {
-        ThrowIfInputFileDoesNotExist(filePath);
-
-        var instance = PreparePacketAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = instance.StartAndWaitForExit();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParsePacketsOutput(result);
+        return AnalyseAsync(filePath, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
     public static IMediaAnalysis Analyse(Uri uri, FFOptions? ffOptions = null, string? customArguments = null)
     {
-        var instance = PrepareStreamAnalysisInstance(uri.AbsoluteUri, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = instance.StartAndWaitForExit();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParseOutput(result);
+        return AnalyseAsync(uri, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
     public static IMediaAnalysis Analyse(Stream stream, FFOptions? ffOptions = null, string? customArguments = null)
     {
-        var streamPipeSource = new StreamPipeSource(stream);
-        var pipeArgument = new InputPipeArgument(streamPipeSource);
-        var instance = PrepareStreamAnalysisInstance(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        pipeArgument.Pre();
-
-        var task = instance.StartAndWaitForExitAsync();
-        try
-        {
-            pipeArgument.During().ConfigureAwait(false).GetAwaiter().GetResult();
-        }
-        catch (IOException) { }
-        finally
-        {
-            pipeArgument.Post();
-        }
-
-        var result = task.ConfigureAwait(false).GetAwaiter().GetResult();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParseOutput(result);
+        return AnalyseAsync(stream, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
     public static async Task<IMediaAnalysis> AnalyseAsync(string filePath, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
@@ -93,35 +37,6 @@ public static class FFProbe
         ThrowIfExitCodeNotZero(result);
 
         return ParseOutput(result);
-    }
-
-    public static FFProbeFrames GetFrames(Uri uri, FFOptions? ffOptions = null, string? customArguments = null)
-    {
-        var instance = PrepareFrameAnalysisInstance(uri.AbsoluteUri, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = instance.StartAndWaitForExit();
-        ThrowIfExitCodeNotZero(result);
-
-        return ParseFramesOutput(result);
-    }
-
-    public static async Task<FFProbeFrames> GetFramesAsync(string filePath, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
-        string? customArguments = null)
-    {
-        ThrowIfInputFileDoesNotExist(filePath);
-
-        var instance = PrepareFrameAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
-        return ParseFramesOutput(result);
-    }
-
-    public static async Task<FFProbePackets> GetPacketsAsync(string filePath, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
-        string? customArguments = null)
-    {
-        ThrowIfInputFileDoesNotExist(filePath);
-
-        var instance = PreparePacketAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
-        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
-        return ParsePacketsOutput(result);
     }
 
     public static async Task<IMediaAnalysis> AnalyseAsync(Uri uri, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
@@ -164,6 +79,31 @@ public static class FFProbe
         return ParseOutput(result);
     }
 
+    public static FFProbeFrames GetFrames(string filePath, FFOptions? ffOptions = null, string? customArguments = null)
+    {
+        return GetFramesAsync(filePath, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    public static FFProbeFrames GetFrames(Uri uri, FFOptions? ffOptions = null, string? customArguments = null)
+    {
+        return GetFramesAsync(uri, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    public static FFProbeFrames GetFrames(Stream stream, FFOptions? ffOptions = null, string? customArguments = null)
+    {
+        return GetFramesAsync(stream, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    public static async Task<FFProbeFrames> GetFramesAsync(string filePath, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
+        string? customArguments = null)
+    {
+        ThrowIfInputFileDoesNotExist(filePath);
+
+        var instance = PrepareFrameAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
+        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        return ParseFramesOutput(result);
+    }
+
     public static async Task<FFProbeFrames> GetFramesAsync(Uri uri, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
         string? customArguments = null)
     {
@@ -195,6 +135,21 @@ public static class FFProbe
         ThrowIfExitCodeNotZero(result);
 
         return ParseFramesOutput(result);
+    }
+
+    public static FFProbePackets GetPackets(string filePath, FFOptions? ffOptions = null, string? customArguments = null)
+    {
+        return GetPacketsAsync(filePath, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    public static async Task<FFProbePackets> GetPacketsAsync(string filePath, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
+        string? customArguments = null)
+    {
+        ThrowIfInputFileDoesNotExist(filePath);
+
+        var instance = PreparePacketAnalysisInstance(filePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
+        var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        return ParsePacketsOutput(result);
     }
 
     private static IMediaAnalysis ParseOutput(IProcessResult instance)

--- a/FFMpegCore/FFProbe/FFProbe.cs
+++ b/FFMpegCore/FFProbe/FFProbe.cs
@@ -22,6 +22,11 @@ public static class FFProbe
         return ParseOutput(result);
     }
 
+    public static FFProbeFrames GetFrames(Stream stream, FFOptions? ffOptions = null, string? customArguments = null)
+    {
+        return GetFramesAsync(stream, ffOptions, CancellationToken.None, customArguments).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
     public static FFProbeFrames GetFrames(string filePath, FFOptions? ffOptions = null, string? customArguments = null)
     {
         ThrowIfInputFileDoesNotExist(filePath);
@@ -164,6 +169,31 @@ public static class FFProbe
     {
         var instance = PrepareFrameAnalysisInstance(uri.AbsoluteUri, ffOptions ?? GlobalFFOptions.Current, customArguments);
         var result = await instance.StartAndWaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        return ParseFramesOutput(result);
+    }
+
+    public static async Task<FFProbeFrames> GetFramesAsync(Stream stream, FFOptions? ffOptions = null, CancellationToken cancellationToken = default,
+        string? customArguments = null)
+    {
+        var streamPipeSource = new StreamPipeSource(stream);
+        var pipeArgument = new InputPipeArgument(streamPipeSource);
+        var instance = PrepareFrameAnalysisInstance(pipeArgument.PipePath, ffOptions ?? GlobalFFOptions.Current, customArguments);
+        pipeArgument.Pre();
+
+        var task = instance.Start().WaitForExitAsync(cancellationToken);
+        try
+        {
+            await pipeArgument.During(cancellationToken).ConfigureAwait(false);
+        }
+        catch (IOException) { }
+        finally
+        {
+            pipeArgument.Post();
+        }
+
+        var result = task.ConfigureAwait(false).GetAwaiter().GetResult();
+        ThrowIfExitCodeNotZero(result);
+
         return ParseFramesOutput(result);
     }
 


### PR DESCRIPTION
Added overloads to the `FFProbe.GetFrames` and `FFProbe.GetFramesAsync` methods to allow passing in Stream objects

* Also refactored the `FFProbe` Analyse and GetFrames methods to all share the same backing logic and reduce code duplication

**Testing Enhancements:**
* Added new tests `FrameAnalysis_FromStream_Sync` and `FrameAnalysis_FromStream_Async` to verify frame extraction from a `Stream` source, both synchronously and asynchronously. [[1]](diffhunk://#diff-1920410b5468a3d73e8f5b769b0a0e9641f2aa553b26ab635fe31873c7f2f2cbR33-R45) [[2]](diffhunk://#diff-1920410b5468a3d73e8f5b769b0a0e9641f2aa553b26ab635fe31873c7f2f2cbR58-R70)