### PR TITLE
Add OutputToNull method to handle the null muxer argument

### DIFF
--- a/FFMpegCore.Test/ArgumentBuilderTest.cs
+++ b/FFMpegCore.Test/ArgumentBuilderTest.cs
@@ -727,4 +727,11 @@ public class ArgumentBuilderTest
         var pipePath = new OutputPipeArgument(new StreamPipeSink(Stream.Null)).PipePath;
         Assert.IsLessThan(_macOsMaxPipePathLength, pipePath.Length);
     }
+
+    [TestMethod]
+    public void Builder_BuildString_Null_Output()
+    {
+        var str = FFMpegArguments.FromFileInput("input.mp4").OutputToNull(opt => opt.WithCustomArgument("-filter_complex ebur128")).Arguments;
+        Assert.AreEqual("-i \"input.mp4\" -filter_complex ebur128 -f null -", str);
+    }
 }

--- a/FFMpegCore/FFMpeg/Arguments/OutputNullArgument.cs
+++ b/FFMpegCore/FFMpeg/Arguments/OutputNullArgument.cs
@@ -1,0 +1,16 @@
+﻿namespace FFMpegCore.Arguments;
+
+public class OutputNullArgument : IOutputArgument
+{
+    public string Text => "-f null -";
+
+    public Task During(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public void Post()
+    {
+    }
+
+    public void Pre()
+    {
+    }
+}

--- a/FFMpegCore/FFMpeg/FFMpegArguments.cs
+++ b/FFMpegCore/FFMpeg/FFMpegArguments.cs
@@ -156,7 +156,7 @@ public sealed class FFMpegArguments : FFMpegArgumentsBase
     {
         return ToProcessor(new OutputPipeArgument(reader), addArguments);
     }
-
+    
     private FFMpegArgumentProcessor ToProcessor(IOutputArgument argument, Action<FFMpegArgumentOptions>? addArguments)
     {
         var args = new FFMpegArgumentOptions();
@@ -179,6 +179,11 @@ public sealed class FFMpegArguments : FFMpegArgumentsBase
         addOutputs(args);
         Arguments.AddRange(args.Arguments);
         return new FFMpegArgumentProcessor(this);
+    }
+    
+    public FFMpegArgumentProcessor OutputToNull(Action<FFMpegArgumentOptions>? addArguments = null)
+    {
+        return ToProcessor(new OutputNullArgument(), addArguments);
     }
 
     internal void Pre()


### PR DESCRIPTION
Add "-f null -" null muxer output handling for cases where there is no output produced.

Ebur128 filter is an example of this case, "ffmpeg -nostats -i input.mp3 -filter_complex ebur128 -f null -".