### PR TITLE
propagate field order from ffprobe

### DIFF
--- a/FFMpegCore.Test/FFProbeTests.cs
+++ b/FFMpegCore.Test/FFProbeTests.cs
@@ -130,6 +130,7 @@ public class FFProbeTests
         Assert.AreEqual(1, info.PrimaryVideoStream.SampleAspectRatio.Height);
         Assert.AreEqual("yuv420p", info.PrimaryVideoStream.PixelFormat);
         Assert.AreEqual(31, info.PrimaryVideoStream.Level);
+        Assert.AreEqual("progressive", info.PrimaryVideoStream.FieldOrder);
         Assert.AreEqual(1280, info.PrimaryVideoStream.Width);
         Assert.AreEqual(720, info.PrimaryVideoStream.Height);
         Assert.AreEqual(25, info.PrimaryVideoStream.AvgFrameRate);

--- a/FFMpegCore/FFProbe/FFProbeAnalysis.cs
+++ b/FFMpegCore/FFProbe/FFProbeAnalysis.cs
@@ -63,6 +63,8 @@ public class FFProbeStream : ITagsContainer, IDispositionContainer
 
     [JsonPropertyName("level")] public int Level { get; set; }
 
+    [JsonPropertyName("field_order")] public string FieldOrder { get; set; } = null!;
+
     [JsonPropertyName("sample_rate")] public string SampleRate { get; set; } = null!;
 
     [JsonPropertyName("side_data_list")] public List<Dictionary<string, JsonValue>> SideData { get; set; } = null!;

--- a/FFMpegCore/FFProbe/MediaAnalysis.cs
+++ b/FFMpegCore/FFProbe/MediaAnalysis.cs
@@ -88,6 +88,7 @@ internal class MediaAnalysis : IMediaAnalysis
             Profile = stream.Profile,
             PixelFormat = stream.PixelFormat,
             Level = stream.Level,
+            FieldOrder = stream.FieldOrder,
             ColorRange = stream.ColorRange,
             ColorSpace = stream.ColorSpace,
             ColorTransfer = stream.ColorTransfer,

--- a/FFMpegCore/FFProbe/VideoStream.cs
+++ b/FFMpegCore/FFProbe/VideoStream.cs
@@ -14,6 +14,7 @@ public class VideoStream : MediaStream
     public double FrameRate { get; set; }
     public string PixelFormat { get; set; } = null!;
     public int Level { get; set; }
+    public string FieldOrder { get; set; } = null!;
     public int Rotation { get; set; }
     public double AverageFrameRate { get; set; }
     public string ColorRange { get; set; } = null!;


### PR DESCRIPTION
I extracted the addition of FieldOrder from https://github.com/rosenbjerg/FFMpegCore/pull/613 as I would really like to have them available.